### PR TITLE
Småfikser på kvittering

### DIFF
--- a/src/main/kotlin/no/nav/familie/oppdrag/iverksetting/KvitteringConstants.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/iverksetting/KvitteringConstants.kt
@@ -6,7 +6,8 @@ enum class Status(val kode: String) {
     OK("00"),
     AKSEPTERT_MEN_NOE_ER_FEIL("04"),
     AVVIST_FUNKSJONELLE_FEIL("08"),
-    AVVIST_TEKNISK_FEIL("12");
+    AVVIST_TEKNISK_FEIL("12"),
+    UKJENT("Ukjent");
 
     companion object {
         fun fraKode(kode: String): Status {

--- a/src/main/kotlin/no/nav/familie/oppdrag/iverksetting/OppdragMottaker.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/iverksetting/OppdragMottaker.kt
@@ -11,14 +11,17 @@ import javax.jms.TextMessage
 class OppdragMottaker(val env: Environment) {
 
     @JmsListener(destination = "\${oppdrag.mq.mottak}")
-    fun mottaKvitteringFraOppdrag(melding: TextMessage): Status {
+    fun mottaKvitteringFraOppdrag(melding: TextMessage) {
         var svarFraOppdrag = melding.text as String
         if (!env.activeProfiles.contains("dev")) {
             svarFraOppdrag = svarFraOppdrag.replace("oppdrag xmlns", "ns2:oppdrag xmlns:ns2")
         }
 
-        val oppdragKvittering = Jaxb().tilOppdrag(svarFraOppdrag)
+        handterKvittering(svarFraOppdrag)
+    }
 
+    fun handterKvittering(svarFraOppdrag: String): Status {
+        val oppdragKvittering = Jaxb().tilOppdrag(svarFraOppdrag)
         val status = hentStatus(oppdragKvittering)
         val fagsakId = hentFagsakId(oppdragKvittering)
         val svarMelding = hentMelding(oppdragKvittering)
@@ -31,11 +34,11 @@ class OppdragMottaker(val env: Environment) {
     }
 
     private fun hentStatus(kvittering: Oppdrag): Status {
-        return Status.fraKode(kvittering.mmel.alvorlighetsgrad)
+        return Status.fraKode(kvittering.mmel?.alvorlighetsgrad ?: "Ukjent")
     }
 
     private fun hentMelding(kvittering: Oppdrag): String {
-        return kvittering.mmel.beskrMelding ?: "Beskrivende melding ikke satt fra OS"
+        return kvittering.mmel?.beskrMelding ?: "Beskrivende melding ikke satt fra OS"
     }
 
     companion object {

--- a/src/test/kotlin/no/nav/familie/oppdrag/iverksetting/OppdragMQMottakTest.kt
+++ b/src/test/kotlin/no/nav/familie/oppdrag/iverksetting/OppdragMQMottakTest.kt
@@ -1,29 +1,16 @@
 package no.nav.familie.oppdrag.iverksetting
 
-import com.ibm.mq.jms.MQConnectionFactory
-import com.ibm.msg.client.wmq.WMQConstants
 import io.mockk.every
 import io.mockk.mockk
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable
 import org.springframework.core.env.Environment
 import java.io.File
-import javax.jms.TextMessage
 import kotlin.test.assertEquals
 
-@DisabledIfEnvironmentVariable(named = "CIRCLECI", matches = "true")
+
 class OppdragMQMottakTest {
 
-    var mqConn = MQConnectionFactory().apply {
-        hostName = "localhost"
-        port = 1414
-        channel = "DEV.ADMIN.SVRCONN"
-        queueManager = "QM1"
-        transportType = WMQConstants.WMQ_CM_CLIENT
-    }.createConnection("admin", "passw0rd")
-
-    val session = mqConn.createSession()
     lateinit var oppdragMottaker: OppdragMottaker
 
     @BeforeEach
@@ -34,24 +21,21 @@ class OppdragMQMottakTest {
         oppdragMottaker = OppdragMottaker(env)
     }
 
-
     @Test
     fun skal_tolke_kvittering_riktig_ved_OK() {
-        val kvittering: TextMessage = lesKvittering("kvittering-akseptert.xml")
-        val statusFraKvittering = oppdragMottaker.mottaKvitteringFraOppdrag(kvittering)
+        val kvittering: String = lesKvittering("kvittering-akseptert.xml")
+        val statusFraKvittering = oppdragMottaker.handterKvittering(kvittering)
         assertEquals(Status.OK, statusFraKvittering)
     }
 
     @Test
     fun skal_tolke_kvittering_riktig_ved_feil() {
-        val kvittering: TextMessage = lesKvittering("kvittering-avvist.xml")
-        val statusFraKvittering = oppdragMottaker.mottaKvitteringFraOppdrag(kvittering)
+        val kvittering: String = lesKvittering("kvittering-avvist.xml")
+        val statusFraKvittering = oppdragMottaker.handterKvittering(kvittering)
         assertEquals(Status.AVVIST_FUNKSJONELLE_FEIL, statusFraKvittering)
     }
 
-    private fun lesKvittering(filnavn: String): TextMessage {
-        val kvittering = File("src/test/resources/$filnavn").inputStream().readBytes().toString(Charsets.UTF_8)
-
-        return session.createTextMessage(kvittering)
+    private fun lesKvittering(filnavn: String): String {
+        return File("src/test/resources/$filnavn").inputStream().readBytes().toString(Charsets.UTF_8)
     }
 }

--- a/src/test/resources/kvittering-akseptert.xml
+++ b/src/test/resources/kvittering-akseptert.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<oppdrag xmlns="http://www.trygdeetaten.no/skjema/oppdrag">
+<ns2:oppdrag xmlns:ns2="http://www.trygdeetaten.no/skjema/oppdrag">
     <mmel>
         <systemId>231-OPPD</systemId>
         <alvorlighetsgrad>00</alvorlighetsgrad>

--- a/src/test/resources/kvittering-avvist.xml
+++ b/src/test/resources/kvittering-avvist.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<oppdrag xmlns="http://www.trygdeetaten.no/skjema/oppdrag">
+<ns2:oppdrag xmlns:ns2="http://www.trygdeetaten.no/skjema/oppdrag">
     <mmel>
         <systemId>231-OPPD</systemId>
         <kodeMelding>B110008F</kodeMelding>


### PR DESCRIPTION
- La til en "Ukjent" status for kvittering for å gjøre det lettere å kjøre lokalt. Alle felter vi trekker ut fra kvittering skal nå være nullsikret. 
- Trakk håndtering av kvittering ut i en egen metode. Spring JMS var ikke så happy med at lytt-metoden returnerte noe (den returnerer til spring jms internt), så for å beholde testbarheten trakk jeg det ut i en egen metode som lytteren kan kalle uten å bruke resultatet til noe. Litt usikker på hvorfor dette bare feilet lokalt og ikke i miljø, men nå fungerer det i hvert fall overalt. 