### PR TITLE
Utvid oppdragsprotokoll med identifiserende felter

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ psql -U postgres
 CREATE DATABASE "familie-oppdrag";
 ```
 
-For å kjøre med denne lokalt må følgende miljøvariabler settes i `application-local.yml`:
+For å kjøre med denne lokalt må følgende miljøvariabler settes i `application-dev.yml`:
 ```
-spring.datasource.url=jdbc:postgresql://0.0.0.0:5432/familie-oppdrag
-spring.datasource.username=postgres
-spring.datasource.password=test
+spring.datasource.url: jdbc:postgresql://0.0.0.0:5432/familie-oppdrag
+spring.datasource.username: postgres
+spring.datasource.password: test
 ```
 
 Les mer om postgres på nav [her](https://github.com/navikt/utvikling/blob/master/PostgreSQL.md). For å hente credentials manuelt, se [her](https://github.com/navikt/utvikling/blob/master/Vault.md). 

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <main-class>no.nav.familie.oppdrag.LauncherKt</main-class>
         <kotlin.version>1.3.50</kotlin.version>
         <felles.version>1.0_20191106113227_c2ad869</felles.version>
-        <kontrakter.version>2.0_20191217102701_8d60148</kontrakter.version>
+        <kontrakter.version>2.0_20200109131607_3484393</kontrakter.version>
         <token-validation-spring.version>1.1.3</token-validation-spring.version>
         <jaxb-api.version>2.3.1</jaxb-api.version>
         <jaxb-core.version>2.3.0.1</jaxb-core.version>

--- a/src/main/kotlin/no/nav/familie/oppdrag/repository/OppdragProtokoll.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/repository/OppdragProtokoll.kt
@@ -8,8 +8,8 @@ import org.springframework.data.relational.core.mapping.Column
 import java.time.LocalDateTime
 
 data class OppdragProtokoll(@Id val serienummer: Long = 0,
-                            val aktoer: String,
                             val fagsystem: String,
+                            @Column("person_id") val personId: String,
                             @Column("fagsak_id") val fagsakId: String,
                             @Column("behandling_id") val behandlingId: String,
                             @Column("input_data") val inputData: String,
@@ -20,7 +20,7 @@ data class OppdragProtokoll(@Id val serienummer: Long = 0,
     companion object {
         fun lagFraOppdrag(utbetalingsoppdrag: Utbetalingsoppdrag, oppdrag : Oppdrag) : OppdragProtokoll {
             return OppdragProtokoll(
-                    aktoer = utbetalingsoppdrag.aktoer,
+                    personId = utbetalingsoppdrag.aktoer,
                     fagsystem = utbetalingsoppdrag.fagSystem,
                     fagsakId = utbetalingsoppdrag.saksnummer,
                     behandlingId = utbetalingsoppdrag.utbetalingsperiode[0].behandlingId.toString(),

--- a/src/main/kotlin/no/nav/familie/oppdrag/repository/OppdragProtokoll.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/repository/OppdragProtokoll.kt
@@ -1,21 +1,30 @@
 package no.nav.familie.oppdrag.repository
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsoppdrag
 import no.trygdeetaten.skjema.oppdrag.Oppdrag
 import org.springframework.data.annotation.Id
 import org.springframework.data.relational.core.mapping.Column
 import java.time.LocalDateTime
 
 data class OppdragProtokoll(@Id val serienummer: Long = 0,
-                            val id : String,
+                            val aktoer: String,
+                            val fagsystem: String,
+                            @Column("fagsak_id") val fagsakId: String,
+                            @Column("behandling_id") val behandlingId: String,
+                            @Column("input_data") val inputData: String,
                             val melding: String,
                             val status: OppdragProtokollStatus = OppdragProtokollStatus.LAGT_PÅ_KØ,
                             @Column("opprettet_tidspunkt") val opprettetTidspunkt: LocalDateTime = LocalDateTime.now()) {
 
     companion object {
-        fun lagFraOppdrag(oppdrag : Oppdrag) : OppdragProtokoll {
+        fun lagFraOppdrag(utbetalingsoppdrag: Utbetalingsoppdrag, oppdrag : Oppdrag) : OppdragProtokoll {
             return OppdragProtokoll(
-                    id = "id", // TODO Plukk "noe" fra oppdrag
+                    aktoer = utbetalingsoppdrag.aktoer,
+                    fagsystem = utbetalingsoppdrag.fagSystem,
+                    fagsakId = utbetalingsoppdrag.saksnummer,
+                    behandlingId = utbetalingsoppdrag.utbetalingsperiode[0].behandlingId.toString(),
+                    inputData = ObjectMapper().writeValueAsString(utbetalingsoppdrag),
                     melding = ObjectMapper().writeValueAsString(oppdrag)
             )
         }

--- a/src/main/kotlin/no/nav/familie/oppdrag/repository/OppdragProtokoll.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/repository/OppdragProtokoll.kt
@@ -2,6 +2,7 @@ package no.nav.familie.oppdrag.repository
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsoppdrag
+import no.nav.familie.kontrakter.felles.oppdrag.behandlingsIdForFørsteUtbetalingsperiode
 import no.trygdeetaten.skjema.oppdrag.Oppdrag
 import org.springframework.data.annotation.Id
 import org.springframework.data.relational.core.mapping.Column
@@ -24,7 +25,7 @@ data class OppdragProtokoll(@Id val serienummer: Long = 0,
                     personIdent = utbetalingsoppdrag.aktoer,
                     fagsystem = utbetalingsoppdrag.fagSystem,
                     fagsakId = utbetalingsoppdrag.saksnummer,
-                    behandlingId = utbetalingsoppdrag.utbetalingsperiode[0].behandlingId.toString(),
+                    behandlingId = utbetalingsoppdrag.behandlingsIdForFørsteUtbetalingsperiode(),
                     avstemmingTidspunkt = utbetalingsoppdrag.avstemmingTidspunkt,
                     inputData = ObjectMapper().writeValueAsString(utbetalingsoppdrag),
                     melding = ObjectMapper().writeValueAsString(oppdrag)

--- a/src/main/kotlin/no/nav/familie/oppdrag/repository/OppdragProtokoll.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/repository/OppdragProtokoll.kt
@@ -9,21 +9,23 @@ import java.time.LocalDateTime
 
 data class OppdragProtokoll(@Id val serienummer: Long = 0,
                             val fagsystem: String,
-                            @Column("person_id") val personId: String,
+                            @Column("person_ident") val personIdent: String,
                             @Column("fagsak_id") val fagsakId: String,
                             @Column("behandling_id") val behandlingId: String,
                             @Column("input_data") val inputData: String,
                             val melding: String,
                             val status: OppdragProtokollStatus = OppdragProtokollStatus.LAGT_PÅ_KØ,
+                            @Column("avstemming_tidspunkt") val avstemmingTidspunkt: LocalDateTime,
                             @Column("opprettet_tidspunkt") val opprettetTidspunkt: LocalDateTime = LocalDateTime.now()) {
 
     companion object {
-        fun lagFraOppdrag(utbetalingsoppdrag: Utbetalingsoppdrag, oppdrag : Oppdrag) : OppdragProtokoll {
+        fun lagFraOppdrag(utbetalingsoppdrag: Utbetalingsoppdrag, oppdrag: Oppdrag): OppdragProtokoll {
             return OppdragProtokoll(
-                    personId = utbetalingsoppdrag.aktoer,
+                    personIdent = utbetalingsoppdrag.aktoer,
                     fagsystem = utbetalingsoppdrag.fagSystem,
                     fagsakId = utbetalingsoppdrag.saksnummer,
                     behandlingId = utbetalingsoppdrag.utbetalingsperiode[0].behandlingId.toString(),
+                    avstemmingTidspunkt = utbetalingsoppdrag.avstemmingTidspunkt,
                     inputData = ObjectMapper().writeValueAsString(utbetalingsoppdrag),
                     melding = ObjectMapper().writeValueAsString(oppdrag)
             )

--- a/src/main/kotlin/no/nav/familie/oppdrag/repository/OppdragProtokollRepository.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/repository/OppdragProtokollRepository.kt
@@ -5,6 +5,6 @@ import org.springframework.data.repository.CrudRepository
 
 interface OppdragProtokollRepository : CrudRepository<OppdragProtokoll, Long> {
 
-    @Query("SELECT * FROM OPPDRAG_PROTOKOLL WHERE behandling_id = :behandlingId AND person_id = :personId AND fagsystem = :fagsystem")
-    fun hentEksisterendeOppdrag(fagsystem: String, behandlingId: String, personId: String): List<OppdragProtokoll>
+    @Query("SELECT * FROM OPPDRAG_PROTOKOLL WHERE behandling_id = :behandlingId AND person_ident = :personIdent AND fagsystem = :fagsystem")
+    fun hentEksisterendeOppdrag(fagsystem: String, behandlingId: String, personIdent: String): List<OppdragProtokoll>
 }

--- a/src/main/kotlin/no/nav/familie/oppdrag/repository/OppdragProtokollRepository.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/repository/OppdragProtokollRepository.kt
@@ -1,5 +1,10 @@
 package no.nav.familie.oppdrag.repository
 
+import org.springframework.data.jdbc.repository.query.Query
 import org.springframework.data.repository.CrudRepository
 
-interface OppdragProtokollRepository : CrudRepository<OppdragProtokoll, Long>
+interface OppdragProtokollRepository : CrudRepository<OppdragProtokoll, Long> {
+
+    @Query("SELECT * FROM OPPDRAG_PROTOKOLL WHERE behandling_id = :behandlingsid AND aktoer = :aktoer AND fagsystem = :fagsystem")
+    fun hentEksisterendeOppdrag(fagsystem: String, behandlingsid: String, aktoer: String): List<OppdragProtokoll>
+}

--- a/src/main/kotlin/no/nav/familie/oppdrag/repository/OppdragProtokollRepository.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/repository/OppdragProtokollRepository.kt
@@ -5,6 +5,6 @@ import org.springframework.data.repository.CrudRepository
 
 interface OppdragProtokollRepository : CrudRepository<OppdragProtokoll, Long> {
 
-    @Query("SELECT * FROM OPPDRAG_PROTOKOLL WHERE behandling_id = :behandlingsid AND aktoer = :aktoer AND fagsystem = :fagsystem")
-    fun hentEksisterendeOppdrag(fagsystem: String, behandlingsid: String, aktoer: String): List<OppdragProtokoll>
+    @Query("SELECT * FROM OPPDRAG_PROTOKOLL WHERE behandling_id = :behandlingId AND person_id = :personId AND fagsystem = :fagsystem")
+    fun hentEksisterendeOppdrag(fagsystem: String, behandlingId: String, personId: String): List<OppdragProtokoll>
 }

--- a/src/main/kotlin/no/nav/familie/oppdrag/rest/OppdragController.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/rest/OppdragController.kt
@@ -2,6 +2,7 @@ package no.nav.familie.oppdrag.rest
 
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsoppdrag
+import no.nav.familie.kontrakter.felles.oppdrag.behandlingsIdForFørsteUtbetalingsperiode
 import no.nav.familie.oppdrag.iverksetting.OppdragMapper
 import no.nav.familie.oppdrag.iverksetting.OppdragSender
 import no.nav.familie.oppdrag.repository.OppdragProtokoll
@@ -30,7 +31,7 @@ class OppdragController(@Autowired val oppdragSender: OppdragSender,
         val oppdrag = oppdragMapper.tilOppdrag(oppdrag110)
 
        if (oppdragProtokollRepository.hentEksisterendeOppdrag(utbetalingsoppdrag.fagSystem,
-                       utbetalingsoppdrag.utbetalingsperiode[0].behandlingId.toString(),
+                       utbetalingsoppdrag.behandlingsIdForFørsteUtbetalingsperiode(),
                        utbetalingsoppdrag.aktoer).isNotEmpty()) {
            return ResponseEntity.badRequest().body(Ressurs.failure("Oppdraget finnes fra før"))
        }

--- a/src/main/kotlin/no/nav/familie/oppdrag/rest/OppdragController.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/rest/OppdragController.kt
@@ -27,9 +27,15 @@ class OppdragController(@Autowired val oppdragSender: OppdragSender,
         val oppdrag110 = oppdragMapper.tilOppdrag110(utbetalingsoppdrag)
         val oppdrag = oppdragMapper.tilOppdrag(oppdrag110)
 
+       if (oppdragProtokollRepository.hentEksisterendeOppdrag(utbetalingsoppdrag.fagSystem,
+                       utbetalingsoppdrag.utbetalingsperiode[0].behandlingId.toString(),
+                       utbetalingsoppdrag.aktoer).isNotEmpty()) {
+           return ResponseEntity.badRequest().body(Ressurs.failure("Oppdraget finnes fra før"))
+       }
+
         // TODO flytt disse to til en @Transactional + @Service type klasse
         oppdragSender.sendOppdrag(oppdrag)
-        oppdragProtokollRepository.save(OppdragProtokoll.lagFraOppdrag(oppdrag))
+        oppdragProtokollRepository.save(OppdragProtokoll.lagFraOppdrag(utbetalingsoppdrag, oppdrag))
         return ResponseEntity.ok().body(Ressurs.Companion.success("Oppdrag sendt ok"))
     }
 }

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -8,3 +8,7 @@ oppdrag.mq:
   user: admin
   password: passw0rd
   enabled: true
+
+spring.datasource.url: jdbc:postgresql://0.0.0.0:5432/familie-oppdrag
+spring.datasource.username: postgres
+spring.datasource.password: test

--- a/src/main/resources/db/migration/V002__fnr_behandlingsid.sql
+++ b/src/main/resources/db/migration/V002__fnr_behandlingsid.sql
@@ -4,8 +4,9 @@ ALTER TABLE oppdrag_protokoll
     DROP COLUMN id;
 
 ALTER TABLE oppdrag_protokoll
-    ADD COLUMN person_id VARCHAR(50) NOT NULL,
+    ADD COLUMN person_ident VARCHAR(50) NOT NULL,
     ADD COLUMN fagsak_id VARCHAR(50) NOT NULL,
     ADD COLUMN behandling_id VARCHAR(50) NOT NULL,
     ADD COLUMN fagsystem VARCHAR(10) NOT NULL,
+    ADD COLUMN avstemming_tidspunkt timestamp(3) NOT NULL,
     ADD COLUMN input_data text NOT NULL;

--- a/src/main/resources/db/migration/V002__fnr_behandlingsid.sql
+++ b/src/main/resources/db/migration/V002__fnr_behandlingsid.sql
@@ -1,0 +1,11 @@
+TRUNCATE oppdrag_protokoll;
+
+ALTER TABLE oppdrag_protokoll
+    DROP COLUMN id;
+
+ALTER TABLE oppdrag_protokoll
+    ADD COLUMN aktoer VARCHAR(50) NOT NULL,
+    ADD COLUMN fagsak_id VARCHAR(50) NOT NULL,
+    ADD COLUMN behandling_id VARCHAR(50) NOT NULL,
+    ADD COLUMN fagsystem VARCHAR(10) NOT NULL,
+    ADD COLUMN input_data text NOT NULL;

--- a/src/main/resources/db/migration/V002__fnr_behandlingsid.sql
+++ b/src/main/resources/db/migration/V002__fnr_behandlingsid.sql
@@ -4,7 +4,7 @@ ALTER TABLE oppdrag_protokoll
     DROP COLUMN id;
 
 ALTER TABLE oppdrag_protokoll
-    ADD COLUMN aktoer VARCHAR(50) NOT NULL,
+    ADD COLUMN person_id VARCHAR(50) NOT NULL,
     ADD COLUMN fagsak_id VARCHAR(50) NOT NULL,
     ADD COLUMN behandling_id VARCHAR(50) NOT NULL,
     ADD COLUMN fagsystem VARCHAR(10) NOT NULL,

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -36,6 +36,5 @@
     <logger name="org.apache.cxf" level="ERROR"/>
     <logger name="org.apache.http.client.protocol.ResponseProcessCookies" level="ERROR"/>
     <logger name="org.apache.wss4j.common.crypto.CryptoBase" level="ERROR"/>
-    <logger name="org.springframework" level="DEBUG" />
 
 </configuration>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -36,5 +36,6 @@
     <logger name="org.apache.cxf" level="ERROR"/>
     <logger name="org.apache.http.client.protocol.ResponseProcessCookies" level="ERROR"/>
     <logger name="org.apache.wss4j.common.crypto.CryptoBase" level="ERROR"/>
+    <logger name="org.springframework" level="DEBUG" />
 
 </configuration>

--- a/src/test/kotlin/no/nav/familie/oppdrag/rest/OppdragControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/oppdrag/rest/OppdragControllerTest.kt
@@ -78,7 +78,8 @@ internal class OppdragControllerTest{
                 "INPUT_DATA",
                 "MELDING",
                 OppdragProtokollStatus.LAGT_PÅ_KØ,
-                LocalDateTime.now())
+                localDateTimeNow,
+                localDateTimeNow)
         val oppdragController = OppdragController(oppdragSender, mapper, oppdragProtokollRepository)
 
         every { oppdragProtokollRepository.hentEksisterendeOppdrag(any(), any(), any()) } answers { listOf(testOppdragsProtokoll) }

--- a/src/test/kotlin/no/nav/familie/oppdrag/rest/OppdragControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/oppdrag/rest/OppdragControllerTest.kt
@@ -25,7 +25,7 @@ internal class OppdragControllerTest{
             Utbetalingsoppdrag.KodeEndring.NY,
             "FAGSYSTEM_TEST",
             "SAKSNR",
-            "AKTØRID",
+            "PERSONID",
             "SAKSBEHANDLERID",
             localDateTimeNow,
             listOf(Utbetalingsperiode(false,
@@ -71,7 +71,7 @@ internal class OppdragControllerTest{
         val oppdragSender = mockk<OppdragSender>(relaxed = true)
         val oppdragProtokollRepository = mockk<OppdragProtokollRepository>()
         val testOppdragsProtokoll = OppdragProtokoll(1,
-                "AKTØRID",
+                "PERSONID",
                 "FAGSYSTEM_TEST",
                 "SAKSNR",
                 "1",

--- a/src/test/kotlin/no/nav/familie/oppdrag/rest/OppdragControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/oppdrag/rest/OppdragControllerTest.kt
@@ -47,9 +47,10 @@ internal class OppdragControllerTest{
         val oppdragSender = mockk<OppdragSender>(relaxed = true)
 
         val oppdragProtokollRepository = mockk<OppdragProtokollRepository>()
+        every { oppdragProtokollRepository.hentEksisterendeOppdrag(any(), any(), any()) } answers { emptyList() }
         every { oppdragProtokollRepository.save(any<OppdragProtokoll>()) } answers { arg(0) }
 
-        val oppdragController = OppdragController(oppdragSender,mapper,oppdragProtokollRepository)
+        val oppdragController = OppdragController(oppdragSender, mapper, oppdragProtokollRepository)
 
         oppdragController.sendOppdrag(utbetalingsoppdrag)
 
@@ -61,5 +62,29 @@ internal class OppdragControllerTest{
                 && it.serienummer == 0L
             })
         }
+    }
+
+    @Test
+    fun skal_ikke_lagre_oppdragsprotokoll_for_eksisterende_oppdrag() {
+
+        val mapper = OppdragMapper()
+        val oppdragSender = mockk<OppdragSender>(relaxed = true)
+        val oppdragProtokollRepository = mockk<OppdragProtokollRepository>()
+        val testOppdragsProtokoll = OppdragProtokoll(1,
+                "AKTØRID",
+                "FAGSYSTEM_TEST",
+                "SAKSNR",
+                "1",
+                "INPUT_DATA",
+                "MELDING",
+                OppdragProtokollStatus.LAGT_PÅ_KØ,
+                LocalDateTime.now())
+        val oppdragController = OppdragController(oppdragSender, mapper, oppdragProtokollRepository)
+
+        every { oppdragProtokollRepository.hentEksisterendeOppdrag(any(), any(), any()) } answers { listOf(testOppdragsProtokoll) }
+
+        oppdragController.sendOppdrag(utbetalingsoppdrag)
+
+        verify (exactly = 0) { oppdragProtokollRepository.save(any<OppdragProtokoll>()) }
     }
 }

--- a/src/test/kotlin/no/nav/familie/oppdrag/rest/OppdragControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/oppdrag/rest/OppdragControllerTest.kt
@@ -12,9 +12,11 @@ import no.nav.familie.oppdrag.repository.OppdragProtokoll
 import no.nav.familie.oppdrag.repository.OppdragProtokollRepository
 import no.nav.familie.oppdrag.repository.OppdragProtokollStatus
 import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
 import java.math.BigDecimal
 import java.time.LocalDate
 import java.time.LocalDateTime
+import kotlin.test.assertEquals
 
 internal class OppdragControllerTest{
 
@@ -84,8 +86,9 @@ internal class OppdragControllerTest{
 
         every { oppdragProtokollRepository.hentEksisterendeOppdrag(any(), any(), any()) } answers { listOf(testOppdragsProtokoll) }
 
-        oppdragController.sendOppdrag(utbetalingsoppdrag)
+         val svar = oppdragController.sendOppdrag(utbetalingsoppdrag)
 
         verify (exactly = 0) { oppdragProtokollRepository.save(any<OppdragProtokoll>()) }
+        assertEquals(HttpStatus.BAD_REQUEST, svar.statusCode)
     }
 }


### PR DESCRIPTION
Legger til personident, fagsakid, behandlingsid og inputdata som egne kolonner i oppdragsprotokollen. Ta en titt på flywayscriptet, det er fortsatt mulig å endre navn etc :) Litt usikker på om vi kommer til å trenge fagsaksiden. Valgte å trunkere tabellen for å slippe å sette default-verdier, men syntaksen er ulik i postgres og H2, så nå må man enten kjøre H2 lokalt uten flyway og bygge opp tabellen manuelt, eller postgres med flyway. La inn postgres-verdiene i application-dev fordi jeg regner med at sistnevnte er enklere, men kan fjerne de igjen hvis dere heller vil kjøre med H2 lokalt. 

Jobi og jeg har litt ulik implementasjon for å hente ut innslag i basen i våre PR-er, ta en titt på begge og let me know hva du syns er best. Jeg har ingen sterke meninger 🙈 

Her er brukerhistorien på Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Tea-214
