### PR TITLE
Bugfix: Ikke sett JMS-headere da OS ikke takler det

### DIFF
--- a/src/main/kotlin/no/nav/familie/oppdrag/avstemming/AvstemmingSenderMQ.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/avstemming/AvstemmingSenderMQ.kt
@@ -20,14 +20,6 @@ class AvstemmingSenderMQ(val jmsTemplateAvstemming: JmsTemplate,
 
         val avstemmingXml = JaxbAvstemmingsdata.tilXml(avstemmingsdata)
         try {
-/*            jmsTemplateAvstemming.send { session ->
-                session.createProducer(
-                        MQQueue(jmsTemplateAvstemming.defaultDestinationName).apply {
-                            targetClient = WMQConstants.WMQ_CLIENT_NONJMS_MQ
-                        })
-                val msg = session.createTextMessage(avstemmingXml)
-                msg
-            }*/
             jmsTemplateAvstemming.convertAndSend(
                     "queue:///${jmsTemplateAvstemming.defaultDestinationName}?targetClient=1",
                     avstemmingXml

--- a/src/main/kotlin/no/nav/familie/oppdrag/avstemming/AvstemmingSenderMQ.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/avstemming/AvstemmingSenderMQ.kt
@@ -20,7 +20,10 @@ class AvstemmingSenderMQ(val jmsTemplateAvstemming: JmsTemplate,
 
         val avstemmingXml = JaxbAvstemmingsdata.tilXml(avstemmingsdata)
         try {
-            jmsTemplateAvstemming.convertAndSend(avstemmingXml)
+            jmsTemplateAvstemming.send { session ->
+                val msg = session.createTextMessage(avstemmingXml)
+                msg
+            }
             LOG.info("Sendt Avstemming-XML på kø ${jmsTemplateAvstemming.defaultDestinationName} til OS")
         } catch (e: JmsException) {
             LOG.error("Klarte ikke sende Avstemming til OS. Feil: ", e)

--- a/src/main/kotlin/no/nav/familie/oppdrag/avstemming/AvstemmingSenderMQ.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/avstemming/AvstemmingSenderMQ.kt
@@ -20,10 +20,7 @@ class AvstemmingSenderMQ(val jmsTemplateAvstemming: JmsTemplate,
 
         val avstemmingXml = JaxbAvstemmingsdata.tilXml(avstemmingsdata)
         try {
-            jmsTemplateAvstemming.send { session ->
-                val msg = session.createTextMessage(avstemmingXml)
-                msg
-            }
+            jmsTemplateAvstemming.convertAndSend(avstemmingXml)
             LOG.info("Sendt Avstemming-XML på kø ${jmsTemplateAvstemming.defaultDestinationName} til OS")
         } catch (e: JmsException) {
             LOG.error("Klarte ikke sende Avstemming til OS. Feil: ", e)

--- a/src/main/kotlin/no/nav/familie/oppdrag/avstemming/AvstemmingSenderMQ.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/avstemming/AvstemmingSenderMQ.kt
@@ -20,10 +20,18 @@ class AvstemmingSenderMQ(val jmsTemplateAvstemming: JmsTemplate,
 
         val avstemmingXml = JaxbAvstemmingsdata.tilXml(avstemmingsdata)
         try {
-            jmsTemplateAvstemming.send { session ->
+/*            jmsTemplateAvstemming.send { session ->
+                session.createProducer(
+                        MQQueue(jmsTemplateAvstemming.defaultDestinationName).apply {
+                            targetClient = WMQConstants.WMQ_CLIENT_NONJMS_MQ
+                        })
                 val msg = session.createTextMessage(avstemmingXml)
                 msg
-            }
+            }*/
+            jmsTemplateAvstemming.convertAndSend(
+                    "queue:///${jmsTemplateAvstemming.defaultDestinationName}?targetClient=1",
+                    avstemmingXml
+            )
             LOG.info("Sendt Avstemming-XML på kø ${jmsTemplateAvstemming.defaultDestinationName} til OS")
         } catch (e: JmsException) {
             LOG.error("Klarte ikke sende Avstemming til OS. Feil: ", e)

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -34,6 +34,7 @@
     <logger name="no.nav.familie" level="INFO"/>
     <logger name="org.apache" level="INFO"/>
     <logger name="org.apache.cxf" level="ERROR"/>
+    <logger name="org.springframework.jms" level="DEBUG" />
     <logger name="org.apache.http.client.protocol.ResponseProcessCookies" level="ERROR"/>
     <logger name="org.apache.wss4j.common.crypto.CryptoBase" level="ERROR"/>
 

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -34,7 +34,7 @@
     <logger name="no.nav.familie" level="INFO"/>
     <logger name="org.apache" level="INFO"/>
     <logger name="org.apache.cxf" level="ERROR"/>
-    <logger name="org.springframework.jms" level="DEBUG" />
+    <logger name="org.springframework.jms" level="DEBUG"/>
     <logger name="org.apache.http.client.protocol.ResponseProcessCookies" level="ERROR"/>
     <logger name="org.apache.wss4j.common.crypto.CryptoBase" level="ERROR"/>
 

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -34,7 +34,6 @@
     <logger name="no.nav.familie" level="INFO"/>
     <logger name="org.apache" level="INFO"/>
     <logger name="org.apache.cxf" level="ERROR"/>
-    <!--<logger name="org.springframework.jms" level="DEBUG"/> -->
     <logger name="org.apache.http.client.protocol.ResponseProcessCookies" level="ERROR"/>
     <logger name="org.apache.wss4j.common.crypto.CryptoBase" level="ERROR"/>
 

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -34,7 +34,7 @@
     <logger name="no.nav.familie" level="INFO"/>
     <logger name="org.apache" level="INFO"/>
     <logger name="org.apache.cxf" level="ERROR"/>
-    <logger name="org.springframework.jms" level="DEBUG"/>
+    <!--<logger name="org.springframework.jms" level="DEBUG"/> -->
     <logger name="org.apache.http.client.protocol.ResponseProcessCookies" level="ERROR"/>
     <logger name="org.apache.wss4j.common.crypto.CryptoBase" level="ERROR"/>
 


### PR DESCRIPTION
Flipper targetclient til 1 når avstemming sendes. Da vil alle JMS-headere fjernes fra meldingen, slik Økonomi ønsker. 