### PR TITLE
Endrer nokkelFom og nokkelTom

### DIFF
--- a/src/main/kotlin/no/nav/familie/oppdrag/grensesnittavstemming/AvstemmingMapper.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/grensesnittavstemming/AvstemmingMapper.kt
@@ -10,7 +10,6 @@ import no.trygdeetaten.skjema.oppdrag.Mmel
 import java.math.BigDecimal
 import java.nio.ByteBuffer
 import java.time.LocalDateTime
-import java.time.LocalTime
 import java.time.format.DateTimeFormatter
 import java.util.*
 
@@ -59,8 +58,8 @@ class AvstemmingMapper(private val oppdragsliste: List<OppdragLager>,
             this.avleverendeKomponentKode = fagOmråde
             this.mottakendeKomponentKode = SystemKode.OPPDRAGSSYSTEMET.kode
             this.underkomponentKode = fagOmråde
-            this.nokkelFom = fom.toLocalDate().atStartOfDay().format(tidspunktFormatter)
-            this.nokkelTom = tom.toLocalDate().atTime(LocalTime.MAX).format(tidspunktFormatter)
+            this.nokkelFom = fom.format(tidspunktFormatter)
+            this.nokkelTom = tom.format(tidspunktFormatter)
             this.avleverendeAvstemmingId = avstemmingId
             this.brukerId = fagOmråde
         }

--- a/src/main/kotlin/no/nav/familie/oppdrag/grensesnittavstemming/AvstemmingMapper.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/grensesnittavstemming/AvstemmingMapper.kt
@@ -10,11 +10,14 @@ import no.trygdeetaten.skjema.oppdrag.Mmel
 import java.math.BigDecimal
 import java.nio.ByteBuffer
 import java.time.LocalDateTime
+import java.time.LocalTime
 import java.time.format.DateTimeFormatter
 import java.util.*
 
 class AvstemmingMapper(private val oppdragsliste: List<OppdragLager>,
-                       private val fagOmråde: String) {
+                       private val fagOmråde: String,
+                       private val fom: LocalDateTime,
+                       private val tom: LocalDateTime) {
     private val ANTALL_DETALJER_PER_MELDING = 70
     private val tidspunktFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd-HH.mm.ss.SSSSSS")
     val avstemmingId = encodeUUIDBase64(UUID.randomUUID())
@@ -56,8 +59,8 @@ class AvstemmingMapper(private val oppdragsliste: List<OppdragLager>,
             this.avleverendeKomponentKode = fagOmråde
             this.mottakendeKomponentKode = SystemKode.OPPDRAGSSYSTEMET.kode
             this.underkomponentKode = fagOmråde
-            this.nokkelFom = getLavesteAvstemmingstidspunkt().format(tidspunktFormatter)
-            this.nokkelTom = getHøyesteAvstemmingstidspunkt().format(tidspunktFormatter)
+            this.nokkelFom = fom.toLocalDate().atStartOfDay().format(tidspunktFormatter)
+            this.nokkelTom = tom.toLocalDate().atTime(LocalTime.MAX).format(tidspunktFormatter)
             this.avleverendeAvstemmingId = avstemmingId
             this.brukerId = fagOmråde
         }

--- a/src/main/kotlin/no/nav/familie/oppdrag/service/AvstemmingService.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/service/AvstemmingService.kt
@@ -17,7 +17,7 @@ class AvstemmingService(
 
     fun utførGrensesnittavstemming(fagsystem: String, fom: LocalDateTime, tom: LocalDateTime) {
         val oppdragSomSkalAvstemmes = oppdragLagerRepository.hentIverksettingerForGrensesnittavstemming(fom, tom, fagsystem)
-        val avstemmingMapper = AvstemmingMapper(oppdragSomSkalAvstemmes, fagsystem)
+        val avstemmingMapper = AvstemmingMapper(oppdragSomSkalAvstemmes, fagsystem, fom, tom)
         val meldinger = avstemmingMapper.lagAvstemmingsmeldinger()
 
         if (meldinger.isEmpty()) {


### PR DESCRIPTION
Endrer nokkelFom og nokkelTom til å være fom og tom vi henter ut oppdrag på, slik sikrer vi at oppdrag også avstemmer mot de samme oppdragene