### PR TITLE
Versjonering, database-del

### DIFF
--- a/src/main/kotlin/no/nav/familie/oppdrag/repository/OppdragLager.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/repository/OppdragLager.kt
@@ -16,14 +16,14 @@ data class OppdragLager(val fagsystem: String,
                         @Column("behandling_id") val behandlingId: String,
                         val utbetalingsoppdrag: String,
                         @Column("utgaaende_oppdrag") val utgåendeOppdrag: String,
-                        val status: OppdragStatus = OppdragStatus.LAGT_PÅ_KØ,
+                        var status: OppdragStatus = OppdragStatus.LAGT_PÅ_KØ,
                         @Column("avstemming_tidspunkt") val avstemmingTidspunkt: LocalDateTime,
                         @Column("opprettet_tidspunkt") val opprettetTidspunkt: LocalDateTime = LocalDateTime.now(),
                         val kvitteringsmelding: String?,
                         val versjon: Int = 0) {
 
     companion object {
-        fun lagFraOppdrag(utbetalingsoppdrag: Utbetalingsoppdrag, oppdrag: Oppdrag): OppdragLager {
+        fun lagFraOppdrag(utbetalingsoppdrag: Utbetalingsoppdrag, oppdrag: Oppdrag, versjon: Int = 0): OppdragLager {
             return OppdragLager(
                     personIdent = utbetalingsoppdrag.aktoer,
                     fagsystem = utbetalingsoppdrag.fagSystem,
@@ -32,11 +32,18 @@ data class OppdragLager(val fagsystem: String,
                     avstemmingTidspunkt = utbetalingsoppdrag.avstemmingTidspunkt,
                     utbetalingsoppdrag = objectMapper.writeValueAsString(utbetalingsoppdrag),
                     utgåendeOppdrag = Jaxb.tilXml(oppdrag),
-                    kvitteringsmelding = null
+                    kvitteringsmelding = null,
+                    versjon = versjon
             )
         }
     }
 
+}
+
+fun Utbetalingsoppdrag.somOppdragLagerMedVersjon(versjon: Int): OppdragLager {
+    val tilOppdrag110 = OppdragMapper().tilOppdrag110(this)
+    val oppdrag = OppdragMapper().tilOppdrag(tilOppdrag110)
+    return OppdragLager.lagFraOppdrag(this, oppdrag, versjon)
 }
 
 val Utbetalingsoppdrag.somOppdragLager: OppdragLager

--- a/src/main/kotlin/no/nav/familie/oppdrag/repository/OppdragLager.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/repository/OppdragLager.kt
@@ -19,7 +19,8 @@ data class OppdragLager(val fagsystem: String,
                         val status: OppdragStatus = OppdragStatus.LAGT_PÅ_KØ,
                         @Column("avstemming_tidspunkt") val avstemmingTidspunkt: LocalDateTime,
                         @Column("opprettet_tidspunkt") val opprettetTidspunkt: LocalDateTime = LocalDateTime.now(),
-                        val kvitteringsmelding: String?) {
+                        val kvitteringsmelding: String?,
+                        val versjon: Int = 0) {
 
     companion object {
         fun lagFraOppdrag(utbetalingsoppdrag: Utbetalingsoppdrag, oppdrag: Oppdrag): OppdragLager {

--- a/src/main/kotlin/no/nav/familie/oppdrag/repository/OppdragLagerRepository.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/repository/OppdragLagerRepository.kt
@@ -7,10 +7,11 @@ import java.time.LocalDateTime
 
 interface OppdragLagerRepository {
 
-    fun hentOppdrag(oppdragId : OppdragId): OppdragLager
-    fun hentUtbetalingsoppdrag(oppdragId: OppdragId): Utbetalingsoppdrag
-    fun opprettOppdrag(oppdragLager: OppdragLager)
-    fun oppdaterStatus(oppdragId: OppdragId, oppdragStatus: OppdragStatus)
-    fun oppdaterKvitteringsmelding(oppdragId: OppdragId, kvittering: Mmel)
+    fun hentOppdrag(oppdragId : OppdragId, versjon: Int = 0): OppdragLager
+    fun hentUtbetalingsoppdrag(oppdragId: OppdragId, versjon: Int = 0): Utbetalingsoppdrag
+    fun hentAlleVersjonerAvOppdrag(oppdragId: OppdragId): List<OppdragLager>
+    fun opprettOppdrag(oppdragLager: OppdragLager, versjon: Int = 0)
+    fun oppdaterStatus(oppdragId: OppdragId, oppdragStatus: OppdragStatus, versjon: Int = 0)
+    fun oppdaterKvitteringsmelding(oppdragId: OppdragId, kvittering: Mmel, versjon: Int = 0)
     fun hentIverksettingerForGrensesnittavstemming(fomTidspunkt: LocalDateTime, tomTidspunkt: LocalDateTime, fagOmråde: String): List<OppdragLager>
 }

--- a/src/main/kotlin/no/nav/familie/oppdrag/repository/OppdragLagerRepositoryJdbc.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/repository/OppdragLagerRepositoryJdbc.kt
@@ -17,11 +17,11 @@ class OppdragLagerRepositoryJdbc(val jdbcTemplate: JdbcTemplate) : OppdragLagerR
 
     internal var LOG = LoggerFactory.getLogger(OppdragLagerRepositoryJdbc::class.java)
 
-    override fun hentOppdrag(oppdragId: OppdragId): OppdragLager {
-        val hentStatement = "SELECT * FROM oppdrag_lager WHERE behandling_id = ? AND person_ident = ? AND fagsystem = ?"
+    override fun hentOppdrag(oppdragId: OppdragId, versjon: Int): OppdragLager {
+        val hentStatement = "SELECT * FROM oppdrag_lager WHERE behandling_id = ? AND person_ident = ? AND fagsystem = ? AND versjon = ?"
 
         val listeAvOppdrag = jdbcTemplate.query(hentStatement,
-                                  arrayOf(oppdragId.behandlingsId, oppdragId.personIdent, oppdragId.fagsystem),
+                                  arrayOf(oppdragId.behandlingsId, oppdragId.personIdent, oppdragId.fagsystem, versjon),
                                   OppdragLagerRowMapper())
 
         return when( listeAvOppdrag.size ) {
@@ -37,8 +37,10 @@ class OppdragLagerRepositoryJdbc(val jdbcTemplate: JdbcTemplate) : OppdragLagerR
         }
     }
 
-    override fun opprettOppdrag(oppdragLager: OppdragLager) {
-        val insertStatement = "INSERT INTO oppdrag_lager VALUES (?,?,?,?,?,?,?,?,?)"
+    override fun opprettOppdrag(oppdragLager: OppdragLager, versjon: Int) {
+        val insertStatement = "INSERT INTO oppdrag_lager " +
+                "(utgaaende_oppdrag, status, opprettet_tidspunkt, person_ident, fagsak_id, behandling_id, fagsystem, avstemming_tidspunkt, utbetalingsoppdrag, versjon)" +
+                " VALUES (?,?,?,?,?,?,?,?,?,?)"
 
         jdbcTemplate.update(insertStatement,
                             oppdragLager.utgåendeOppdrag,
@@ -49,27 +51,30 @@ class OppdragLagerRepositoryJdbc(val jdbcTemplate: JdbcTemplate) : OppdragLagerR
                             oppdragLager.behandlingId,
                             oppdragLager.fagsystem,
                             oppdragLager.avstemmingTidspunkt,
-                            oppdragLager.utbetalingsoppdrag)
+                            oppdragLager.utbetalingsoppdrag,
+                            versjon)
     }
 
-    override fun oppdaterStatus(oppdragId: OppdragId, oppdragStatus: OppdragStatus) {
+    override fun oppdaterStatus(oppdragId: OppdragId, oppdragStatus: OppdragStatus, versjon: Int) {
 
         val update = "UPDATE oppdrag_lager SET status = '${oppdragStatus.name}' " +
                      "WHERE person_ident = '${oppdragId.personIdent}' " +
                      "AND fagsystem = '${oppdragId.fagsystem}' " +
-                     "AND behandling_id = '${oppdragId.behandlingsId}'"
+                     "AND behandling_id = '${oppdragId.behandlingsId}'" +
+                     "AND versjon = $versjon"
 
         jdbcTemplate.execute(update)
     }
 
-    override fun oppdaterKvitteringsmelding(oppdragId: OppdragId, kvittering: Mmel) {
-        val updateStatement = "UPDATE oppdrag_lager SET kvitteringsmelding = ? WHERE person_ident = ? AND fagsystem = ? AND behandling_id = ?"
+    override fun oppdaterKvitteringsmelding(oppdragId: OppdragId, kvittering: Mmel, versjon: Int) {
+        val updateStatement = "UPDATE oppdrag_lager SET kvitteringsmelding = ? WHERE person_ident = ? AND fagsystem = ? AND behandling_id = ? AND versjon = ?"
 
         jdbcTemplate.update(updateStatement,
                 objectMapper.writeValueAsString(kvittering),
                 oppdragId.personIdent,
                 oppdragId.fagsystem,
-                oppdragId.behandlingsId)
+                oppdragId.behandlingsId,
+                versjon)
     }
 
     override fun hentIverksettingerForGrensesnittavstemming(fomTidspunkt: LocalDateTime, tomTidspunkt: LocalDateTime, fagOmråde: String): List<OppdragLager> {
@@ -80,16 +85,23 @@ class OppdragLagerRepositoryJdbc(val jdbcTemplate: JdbcTemplate) : OppdragLagerR
                 OppdragLagerRowMapper())
     }
 
-    override fun hentUtbetalingsoppdrag(oppdragId: OppdragId): Utbetalingsoppdrag {
-        val hentStatement = "SELECT utbetalingsoppdrag FROM oppdrag_lager WHERE behandling_id = ? AND person_ident = ? AND fagsystem = ?"
+    override fun hentUtbetalingsoppdrag(oppdragId: OppdragId, versjon: Int): Utbetalingsoppdrag {
+        val hentStatement = "SELECT utbetalingsoppdrag FROM oppdrag_lager WHERE behandling_id = ? AND person_ident = ? AND fagsystem = ? AND versjon = ?"
 
         val jsonUtbetalingsoppdrag = jdbcTemplate.queryForObject(hentStatement,
-                arrayOf(oppdragId.behandlingsId, oppdragId.personIdent, oppdragId.fagsystem),
+                arrayOf(oppdragId.behandlingsId, oppdragId.personIdent, oppdragId.fagsystem, versjon),
                 String::class.java)
 
         return objectMapper.readValue(jsonUtbetalingsoppdrag)
     }
 
+    override fun hentAlleVersjonerAvOppdrag(oppdragId: OppdragId): List<OppdragLager> {
+        val hentStatement = "SELECT * FROM oppdrag_lager WHERE behandling_id = ? AND person_ident = ? AND fagsystem = ?"
+
+        return jdbcTemplate.query(hentStatement,
+                arrayOf(oppdragId.behandlingsId, oppdragId.personIdent, oppdragId.fagsystem),
+                OppdragLagerRowMapper())
+    }
 }
 
 class OppdragLagerRowMapper : RowMapper<OppdragLager> {
@@ -105,6 +117,7 @@ class OppdragLagerRowMapper : RowMapper<OppdragLager> {
                 OppdragStatus.valueOf(resultSet.getString(2)),
                 resultSet.getTimestamp(8).toLocalDateTime(),
                 resultSet.getTimestamp(3).toLocalDateTime(),
-                resultSet.getString(10))
+                resultSet.getString(10),
+                resultSet.getInt(11))
     }
 }

--- a/src/main/resources/db/migration/V008__versjonering.sql
+++ b/src/main/resources/db/migration/V008__versjonering.sql
@@ -1,0 +1,2 @@
+ALTER TABLE oppdrag_lager
+    ADD COLUMN versjon BIGINT NOT NULL DEFAULT 0;

--- a/src/main/resources/db/migration/V008__versjonering.sql
+++ b/src/main/resources/db/migration/V008__versjonering.sql
@@ -1,2 +1,4 @@
 ALTER TABLE oppdrag_lager
-    ADD COLUMN versjon BIGINT NOT NULL DEFAULT 0;
+    DROP CONSTRAINT oppdrag_protokoll_pkey,
+    ADD COLUMN versjon BIGINT NOT NULL DEFAULT 0,
+    ADD CONSTRAINT oppdrag_lager_pkey PRIMARY KEY (person_ident, behandling_id, fagsystem, versjon);

--- a/src/test/kotlin/no/nav/familie/oppdrag/konsistensavstemming/KonsistensavstemmingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/oppdrag/konsistensavstemming/KonsistensavstemmingServiceTest.kt
@@ -1,0 +1,52 @@
+package no.nav.familie.oppdrag.konsistensavstemming
+
+import io.mockk.*
+import no.nav.familie.oppdrag.avstemming.AvstemmingSender
+import no.nav.familie.oppdrag.repository.OppdragLagerRepository
+import no.nav.familie.oppdrag.repository.OppdragStatus
+import no.nav.familie.oppdrag.repository.somOppdragLager
+import no.nav.familie.oppdrag.repository.somOppdragLagerMedVersjon
+import no.nav.familie.oppdrag.rest.OppdragIdForFagsystem
+import no.nav.familie.oppdrag.service.KonsistensavstemmingService
+import no.nav.familie.oppdrag.util.TestUtbetalingsoppdrag
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+
+class KonsistensavstemmingServiceTest {
+
+    lateinit var konsistensavstemmingService: KonsistensavstemmingService
+    lateinit var oppdragLagerRepository: OppdragLagerRepository
+    lateinit var avstemmingSender: AvstemmingSender
+
+    @BeforeEach
+    fun setUp() {
+        oppdragLagerRepository = mockk()
+        avstemmingSender = mockk<AvstemmingSender>()
+        konsistensavstemmingService = KonsistensavstemmingService(avstemmingSender, oppdragLagerRepository)
+    }
+
+    @Test
+    fun skal_konsistensavstemme_riktig_versjon() {
+        val oppdrag = TestUtbetalingsoppdrag.utbetalingsoppdragMedTilfeldigAktoer().somOppdragLager
+                .apply { status = OppdragStatus.KVITTERT_FUNKSJONELL_FEIL }
+        val oppdragV1 = TestUtbetalingsoppdrag.utbetalingsoppdragMedTilfeldigAktoer().somOppdragLagerMedVersjon(1)
+                .apply { status = OppdragStatus.KVITTERT_OK }
+
+        every { oppdragLagerRepository.hentAlleVersjonerAvOppdrag(any()) } returns
+                listOf(oppdrag, oppdragV1)
+        every { oppdragLagerRepository.hentUtbetalingsoppdrag(any(), any()) } returns
+                TestUtbetalingsoppdrag.utbetalingsoppdragMedTilfeldigAktoer()
+        every { avstemmingSender.sendKonsistensAvstemming(any()) } just Runs
+
+        konsistensavstemmingService.utførKonsistensavstemming(
+                "BA",
+                listOf(OppdragIdForFagsystem(oppdrag.personIdent, oppdrag.behandlingId.toLong())),
+                LocalDateTime.now()
+        )
+
+        verify (exactly = 4) { avstemmingSender.sendKonsistensAvstemming(any()) }
+        verify (exactly = 0) { oppdragLagerRepository.hentUtbetalingsoppdrag(any(), 0) }
+        verify (exactly = 1) { oppdragLagerRepository.hentUtbetalingsoppdrag(any(), 1) }
+    }
+}


### PR DESCRIPTION
Gjør det mulig å ha flere versjoner av et oppdrag for samme person, behandling og fagsystem. Må kobles på endepunkt-delen, da flere versjoner kun skal brukes når vi får feil-kvittering fra Økonomi. 