### PR TITLE
Feil i beregningen på etterutbetaling

### DIFF
--- a/src/main/kotlin/no/nav/familie/oppdrag/simulering/SimulerBeregningResponseMapper.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/simulering/SimulerBeregningResponseMapper.kt
@@ -19,7 +19,7 @@ fun SimulerBeregningResponse.toRestSimulerResult(
 private fun finnEtterbetalingPerPeriode(beregningsPeriode: BeregningsPeriode, dato: LocalDate, kodeFagomraade: String = "BA"): Int {
     // Fremtidige perioder gir ingen etterbetaling.
     val datoFraPeriode = LocalDate.parse(beregningsPeriode.periodeFom, DateTimeFormatter.ISO_DATE)
-    if (datoFraPeriode.month > dato.month) return 0
+    if (datoFraPeriode > dato) return 0
 
     val stoppNivaBA =
             beregningsPeriode.beregningStoppnivaa.filter { it.kodeFagomraade?.trim() == kodeFagomraade }

--- a/src/test/kotlin/no/nav/familie/oppdrag/simulering/SimulerBeregningResponseMapperTest.kt
+++ b/src/test/kotlin/no/nav/familie/oppdrag/simulering/SimulerBeregningResponseMapperTest.kt
@@ -1,10 +1,9 @@
 package no.nav.familie.oppdrag.simulering
 
 import no.nav.familie.oppdrag.simulering.util.*
+import no.nav.system.os.entiteter.beregningskjema.BeregningsPeriode
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import java.time.LocalDate
 import java.time.Month
@@ -82,5 +81,20 @@ class SimulerBeregningResponseMapperTest() {
         val dto = response.toRestSimulerResult(dagensDato)
 
         assertEquals(0, dto.etterbetaling)
+    }
+
+    @Test
+    fun bergen_et_år() {
+        val beregningsPerioder = mutableListOf<BeregningsPeriode>()
+
+        for (manedNr in 1L..12L) {
+            val maned = dagensDato.minusMonths(manedNr)
+            beregningsPerioder.add(lagBeregningsPeriode(listOf(lagBeregningStoppniva(maned)), maned))
+        }
+
+        val response = lagSimulerBeregningResponse(beregningsPerioder.toList())
+        val dto = response.toRestSimulerResult(dagensDato)
+
+        assertEquals(12000, dto.etterbetaling)
     }
 }


### PR DESCRIPTION
Når periode skal sjekkes om fremover i tid så sjekkes maneden men ikke året. (Vi kan sjekke på datumet direkte ettersom fra dato alltid er første i måneden)