### PR TITLE
Avstemming : Legger til en mapper fra fagområde til avleverendekomponentkode for…

### DIFF
--- a/src/main/kotlin/no/nav/familie/oppdrag/avstemming/AvstemmingMapper.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/avstemming/AvstemmingMapper.kt
@@ -3,13 +3,21 @@ package no.nav.familie.oppdrag.avstemming
 import java.nio.ByteBuffer
 import java.util.*
 
-class AvstemmingMapper {
+object AvstemmingMapper {
 
     fun encodeUUIDBase64(uuid: UUID): String {
         val bb = ByteBuffer.wrap(ByteArray(16))
         bb.putLong(uuid.mostSignificantBits)
         bb.putLong(uuid.leastSignificantBits)
         return Base64.getUrlEncoder().encodeToString(bb.array()).substring(0, 22)
+    }
+
+    fun fagområdeTilAvleverendeKomponentKode(fagområde: String): String {
+        return when(fagområde) {
+            "EFOG" -> "EF"
+            "BA" -> "BA"
+            else -> throw Error("Grensesnittavstemming støttes ikke for $fagområde")
+        }
     }
 }
 

--- a/src/main/kotlin/no/nav/familie/oppdrag/grensesnittavstemming/GrensesnittavstemmingMapper.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/grensesnittavstemming/GrensesnittavstemmingMapper.kt
@@ -5,6 +5,7 @@ import no.nav.familie.kontrakter.felles.objectMapper
 import no.nav.familie.kontrakter.felles.oppdrag.OppdragStatus
 import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsoppdrag
 import no.nav.familie.oppdrag.avstemming.AvstemmingMapper
+import no.nav.familie.oppdrag.avstemming.AvstemmingMapper.fagområdeTilAvleverendeKomponentKode
 import no.nav.familie.oppdrag.avstemming.SystemKode
 import no.nav.familie.oppdrag.repository.OppdragLager
 import no.nav.virksomhet.tjenester.avstemming.meldinger.v1.*
@@ -15,12 +16,12 @@ import java.time.format.DateTimeFormatter
 import java.util.*
 
 class GrensesnittavstemmingMapper(private val oppdragsliste: List<OppdragLager>,
-                                  private val fagOmråde: String,
+                                  private val fagområde: String,
                                   private val fom: LocalDateTime,
                                   private val tom: LocalDateTime) {
     private val ANTALL_DETALJER_PER_MELDING = 70
     private val tidspunktFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd-HH.mm.ss.SSSSSS")
-    val avstemmingId = AvstemmingMapper().encodeUUIDBase64(UUID.randomUUID())
+    val avstemmingId = AvstemmingMapper.encodeUUIDBase64(UUID.randomUUID())
 
     fun lagAvstemmingsmeldinger() : List<Avstemmingsdata> {
         if (oppdragsliste.isEmpty())
@@ -56,13 +57,13 @@ class GrensesnittavstemmingMapper(private val oppdragsliste: List<OppdragLager>,
             this.aksjonType = aksjonType
             this.kildeType = KildeType.AVLEV
             this.avstemmingType = AvstemmingType.GRSN
-            this.avleverendeKomponentKode = fagOmråde
+            this.avleverendeKomponentKode = fagområdeTilAvleverendeKomponentKode(fagområde)
             this.mottakendeKomponentKode = SystemKode.OPPDRAGSSYSTEMET.kode
-            this.underkomponentKode = fagOmråde
+            this.underkomponentKode = fagområde
             this.nokkelFom = fom.format(tidspunktFormatter)
             this.nokkelTom = tom.format(tidspunktFormatter)
             this.avleverendeAvstemmingId = avstemmingId
-            this.brukerId = fagOmråde
+            this.brukerId = fagområde
         }
     }
 
@@ -82,7 +83,7 @@ class GrensesnittavstemmingMapper(private val oppdragsliste: List<OppdragLager>,
                 Detaljdata().apply {
                     this.detaljType = detaljType
                     this.offnr = utbetalingsoppdrag.aktoer
-                    this.avleverendeTransaksjonNokkel = fagOmråde
+                    this.avleverendeTransaksjonNokkel = fagområde
                     this.tidspunkt = oppdrag.avstemmingTidspunkt.format(tidspunktFormatter)
                     if (detaljType in listOf(DetaljType.AVVI, DetaljType.VARS) && oppdrag.kvitteringsmelding != null) {
                         val kvitteringsmelding = fraKvitteringTilKvitteringsmelding(oppdrag.kvitteringsmelding)

--- a/src/main/kotlin/no/nav/familie/oppdrag/konsistensavstemming/KonsistensavstemmingMapper.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/konsistensavstemming/KonsistensavstemmingMapper.kt
@@ -18,7 +18,7 @@ class KonsistensavstemmingMapper(private val fagsystem: String,
                                  private val avstemmingsDato: LocalDateTime) {
     private val tidspunktFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd-HH.mm.ss.SSSSSS")
     private val datoFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd")
-    val avstemmingId = AvstemmingMapper().encodeUUIDBase64(UUID.randomUUID())
+    val avstemmingId = AvstemmingMapper.encodeUUIDBase64(UUID.randomUUID())
     var totalBeløp = 0L
     var totalantall = 0
 
@@ -146,7 +146,7 @@ class KonsistensavstemmingMapper(private val fagsystem: String,
             this.aksjonsType = aksjonstype
             this.kildeType = KonsistensavstemmingConstants.KILDETYPE
             this.avstemmingType = KonsistensavstemmingConstants.KONSISTENSAVSTEMMING
-            this.avleverendeKomponentKode = fagsystem
+            this.avleverendeKomponentKode = AvstemmingMapper.fagområdeTilAvleverendeKomponentKode(fagsystem)
             this.mottakendeKomponentKode = SystemKode.OPPDRAGSSYSTEMET.kode
             this.underkomponentKode = fagsystem
             this.tidspunktAvstemmingTom = avstemmingsDato.format(tidspunktFormatter)


### PR DESCRIPTION
… tilpasse behovene i ef.  I EF så har vi tre forskjellige ytelser vi ska avstemme for. Disse har forskjellige underkomponentkode (eks EFOG) men samme avleverendekomponentkode (i.e EF) og derfør trenger vi en mapper.