### PR TITLE
Sett riktig kodekomponent på Avstemming115 i oppdrag som iverksettes

### DIFF
--- a/src/main/kotlin/no/nav/familie/oppdrag/grensesnittavstemming/GrensesnittavstemmingMapper.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/grensesnittavstemming/GrensesnittavstemmingMapper.kt
@@ -83,7 +83,7 @@ class GrensesnittavstemmingMapper(private val oppdragsliste: List<OppdragLager>,
                 Detaljdata().apply {
                     this.detaljType = detaljType
                     this.offnr = utbetalingsoppdrag.aktoer
-                    this.avleverendeTransaksjonNokkel = fagområdeTilAvleverendeKomponentKode(fagområde)
+                    this.avleverendeTransaksjonNokkel = fagområde
                     this.tidspunkt = oppdrag.avstemmingTidspunkt.format(tidspunktFormatter)
                     if (detaljType in listOf(DetaljType.AVVI, DetaljType.VARS) && oppdrag.kvitteringsmelding != null) {
                         val kvitteringsmelding = fraKvitteringTilKvitteringsmelding(oppdrag.kvitteringsmelding)

--- a/src/main/kotlin/no/nav/familie/oppdrag/grensesnittavstemming/GrensesnittavstemmingMapper.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/grensesnittavstemming/GrensesnittavstemmingMapper.kt
@@ -83,7 +83,7 @@ class GrensesnittavstemmingMapper(private val oppdragsliste: List<OppdragLager>,
                 Detaljdata().apply {
                     this.detaljType = detaljType
                     this.offnr = utbetalingsoppdrag.aktoer
-                    this.avleverendeTransaksjonNokkel = fagområde
+                    this.avleverendeTransaksjonNokkel = fagområdeTilAvleverendeKomponentKode(fagområde)
                     this.tidspunkt = oppdrag.avstemmingTidspunkt.format(tidspunktFormatter)
                     if (detaljType in listOf(DetaljType.AVVI, DetaljType.VARS) && oppdrag.kvitteringsmelding != null) {
                         val kvitteringsmelding = fraKvitteringTilKvitteringsmelding(oppdrag.kvitteringsmelding)

--- a/src/main/kotlin/no/nav/familie/oppdrag/iverksetting/OppdragMapper.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/iverksetting/OppdragMapper.kt
@@ -2,6 +2,7 @@ package no.nav.familie.oppdrag.iverksetting
 
 import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsoppdrag
 import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsperiode
+import no.nav.familie.oppdrag.avstemming.AvstemmingMapper.fagområdeTilAvleverendeKomponentKode
 import no.trygdeetaten.skjema.oppdrag.*
 import org.springframework.stereotype.Component
 import java.time.format.DateTimeFormatter
@@ -16,7 +17,7 @@ class OppdragMapper {
 
         val avstemming = objectFactory.createAvstemming115().apply {
             nokkelAvstemming = utbetalingsoppdrag.avstemmingTidspunkt.format(tidspunktFormatter)
-            kodeKomponent = utbetalingsoppdrag.fagSystem
+            kodeKomponent = fagområdeTilAvleverendeKomponentKode(utbetalingsoppdrag.fagSystem)
             tidspktMelding = utbetalingsoppdrag.avstemmingTidspunkt.format(tidspunktFormatter)
         }
 

--- a/src/test/kotlin/no/nav/familie/oppdrag/repository/OppdragLagerRepositoryJdbcTest.kt
+++ b/src/test/kotlin/no/nav/familie/oppdrag/repository/OppdragLagerRepositoryJdbcTest.kt
@@ -96,7 +96,7 @@ internal class OppdragLagerRepositoryJdbcTest {
 
         val baOppdragLager = TestOppdragMedAvstemmingsdato.lagTestUtbetalingsoppdrag(avstemmingsTidspunktetSomSkalKjøres, "BA").somOppdragLager
         val baOppdragLager2 = TestOppdragMedAvstemmingsdato.lagTestUtbetalingsoppdrag(LocalDateTime.now().minusDays(1), "BA").somOppdragLager
-        val efOppdragLager = TestOppdragMedAvstemmingsdato.lagTestUtbetalingsoppdrag(LocalDateTime.now(), "EF").somOppdragLager
+        val efOppdragLager = TestOppdragMedAvstemmingsdato.lagTestUtbetalingsoppdrag(LocalDateTime.now(), "EFOG").somOppdragLager
 
         oppdragLagerRepository.opprettOppdrag(baOppdragLager)
         oppdragLagerRepository.opprettOppdrag(baOppdragLager2)

--- a/src/test/kotlin/no/nav/familie/oppdrag/util/TestUtbetalingsoppdrag.kt
+++ b/src/test/kotlin/no/nav/familie/oppdrag/util/TestUtbetalingsoppdrag.kt
@@ -15,7 +15,7 @@ object TestUtbetalingsoppdrag {
 
     fun utbetalingsoppdragMedTilfeldigAktoer() = Utbetalingsoppdrag(
             Utbetalingsoppdrag.KodeEndring.NY,
-            "BA",
+            "EFOG",
             "SAKSNR",
             UUID.randomUUID().toString(), // Foreløpig plass til en 50-tegn string og ingen gyldighetssjekk
             "SAKSBEHANDLERID",

--- a/src/test/kotlin/no/nav/familie/oppdrag/util/TestUtbetalingsoppdrag.kt
+++ b/src/test/kotlin/no/nav/familie/oppdrag/util/TestUtbetalingsoppdrag.kt
@@ -15,7 +15,7 @@ object TestUtbetalingsoppdrag {
 
     fun utbetalingsoppdragMedTilfeldigAktoer() = Utbetalingsoppdrag(
             Utbetalingsoppdrag.KodeEndring.NY,
-            "TEST",
+            "BA",
             "SAKSNR",
             UUID.randomUUID().toString(), // Foreløpig plass til en 50-tegn string og ingen gyldighetssjekk
             "SAKSBEHANDLERID",


### PR DESCRIPTION
EF-ytelsene må ha koden "EF" her da vi har én felles komponentkode for avstemming. Tar i bruk mapperen vi har laget for avstemming for å sikre konsistens her. 