### PR TITLE
Lager en ny endepunkt for å kunne konsistensavstemme med utbetalingso…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <kotlin.version>1.4.32</kotlin.version>
         <common-java-modules.version>2.2021.05.03_09.21-91f2fc8f059e</common-java-modules.version>
         <felles.version>1.20210419103325_d044927</felles.version>
-        <kontrakter.version>2.0_20210506101703_8c0e695</kontrakter.version>
+        <kontrakter.version>2.0-SNAPSHOT</kontrakter.version> <!-- Oppdaterer før merge -->
         <token-validation-spring.version>1.3.7</token-validation-spring.version>
         <jaxb-api.version>2.3.1</jaxb-api.version>
         <jaxb-core.version>3.0.1</jaxb-core.version>

--- a/src/main/kotlin/no/nav/familie/oppdrag/service/KonsistensavstemmingService.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/service/KonsistensavstemmingService.kt
@@ -1,6 +1,7 @@
 package no.nav.familie.oppdrag.service
 
 import no.nav.familie.kontrakter.felles.oppdrag.KonsistensavstemmingRequestV2
+import no.nav.familie.kontrakter.felles.oppdrag.KonsistensavstemmingUtbetalingsoppdrag
 import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsoppdrag
 import no.nav.familie.oppdrag.avstemming.AvstemmingSender
 import no.nav.familie.oppdrag.konsistensavstemming.KonsistensavstemmingMapper
@@ -17,6 +18,10 @@ class KonsistensavstemmingService(
         private val avstemmingSender: AvstemmingSender,
         private val oppdragLagerRepository: OppdragLagerRepository,
 ) {
+
+    fun utførKonsistensavstemming(request: KonsistensavstemmingUtbetalingsoppdrag) {
+        utførKonsistensavstemming(request.fagsystem, request.utbetalingsoppdrag, request.avstemmingstidspunkt)
+    }
 
     private fun utførKonsistensavstemming(
             fagsystem: String,


### PR DESCRIPTION
…ppdrag slik att man sjekker att det ikke er forskjell mellom perioder/beløp i saksbehandling og økonomisystemet. Dagens løsning er att vi sender ivei periodeIdn til oppdrag og så hentes oppdrag side periodeidn og beløp opp. Ulempen er att vi kommer sende mer data til oppdrag, men oppdrag vil fungere mer som en proxy uten logikk ved konsistensavstemming.

Oppdater kontrakter etter att https://github.com/navikt/familie-kontrakter/pull/349 er merget

https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-4783