### PR TITLE
Legger til prefix på saksnummer i test då økonomi laster in data fra …

### DIFF
--- a/src/main/kotlin/no/nav/familie/oppdrag/common/FagsakIdUtil.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/common/FagsakIdUtil.kt
@@ -1,0 +1,13 @@
+package no.nav.familie.oppdrag.common
+
+import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsoppdrag
+
+fun Utbetalingsoppdrag.fagsystemId(springProfile: String = getSpringProfile()): String {
+    return if (springProfile.contains("preprod")) {
+        "0" + this.saksnummer
+    } else {
+        this.saksnummer
+    }
+}
+
+private fun getSpringProfile() = System.getenv("SPRING_PROFILES_ACTIVE") ?: ""

--- a/src/main/kotlin/no/nav/familie/oppdrag/iverksetting/OppdragMapper.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/iverksetting/OppdragMapper.kt
@@ -3,6 +3,7 @@ package no.nav.familie.oppdrag.iverksetting
 import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsoppdrag
 import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsperiode
 import no.nav.familie.oppdrag.avstemming.AvstemmingMapper.fagområdeTilAvleverendeKomponentKode
+import no.nav.familie.oppdrag.common.fagsystemId
 import no.trygdeetaten.skjema.oppdrag.*
 import org.springframework.stereotype.Component
 import java.time.format.DateTimeFormatter
@@ -31,7 +32,7 @@ class OppdragMapper {
             kodeAksjon = OppdragSkjemaConstants.KODE_AKSJON
             kodeEndring = EndringsKode.fromKode(utbetalingsoppdrag.kodeEndring.name).kode
             kodeFagomraade = utbetalingsoppdrag.fagSystem
-            fagsystemId = utbetalingsoppdrag.saksnummer
+            fagsystemId = utbetalingsoppdrag.fagsystemId()
             utbetFrekvens = UtbetalingsfrekvensKode.MÅNEDLIG.kode
             oppdragGjelderId = utbetalingsoppdrag.aktoer
             datoOppdragGjelderFom = OppdragSkjemaConstants.OPPDRAG_GJELDER_DATO_FOM.toXMLDate()
@@ -60,12 +61,12 @@ class OppdragMapper {
             }
             if (!utbetalingsperiode.erEndringPåEksisterendePeriode) {
                 utbetalingsperiode.forrigePeriodeId?.let {
-                    refDelytelseId = utbetalingsoppdrag.saksnummer + it
-                    refFagsystemId = utbetalingsoppdrag.saksnummer
+                    refDelytelseId = utbetalingsoppdrag.fagsystemId() + it
+                    refFagsystemId = utbetalingsoppdrag.fagsystemId()
                 }
             }
             vedtakId = utbetalingsperiode.datoForVedtak.toString()
-            delytelseId = utbetalingsoppdrag.saksnummer + utbetalingsperiode.periodeId
+            delytelseId = utbetalingsoppdrag.fagsystemId() + utbetalingsperiode.periodeId
             kodeKlassifik = utbetalingsperiode.klassifisering
             datoVedtakFom = utbetalingsperiode.vedtakdatoFom.toXMLDate()
             datoVedtakTom = utbetalingsperiode.vedtakdatoTom.toXMLDate()

--- a/src/main/kotlin/no/nav/familie/oppdrag/konsistensavstemming/KonsistensavstemmingMapper.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/konsistensavstemming/KonsistensavstemmingMapper.kt
@@ -4,6 +4,7 @@ import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsoppdrag
 import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsperiode
 import no.nav.familie.oppdrag.avstemming.AvstemmingMapper
 import no.nav.familie.oppdrag.avstemming.SystemKode
+import no.nav.familie.oppdrag.common.fagsystemId
 import no.nav.familie.oppdrag.iverksetting.GradTypeKode
 import no.nav.familie.oppdrag.iverksetting.OppdragSkjemaConstants
 import no.nav.familie.oppdrag.iverksetting.SatsTypeKode
@@ -41,8 +42,8 @@ class KonsistensavstemmingMapper(private val fagsystem: String,
         val dataListe: MutableList<Konsistensavstemmingsdata> = arrayListOf()
 
         for (utbetalingsoppdrag in utbetalingsoppdrag) {
-            if (!behandledeSaker.add(utbetalingsoppdrag.saksnummer))
-                error("Har allerede lagt til ${utbetalingsoppdrag.saksnummer} i listen over avstemminger")
+            if (!behandledeSaker.add(utbetalingsoppdrag.fagsystemId()))
+                error("Har allerede lagt til ${utbetalingsoppdrag.fagsystemId()} i listen over avstemminger")
 
             val konsistensavstemmingsdata = lagAksjonsmelding(KonsistensavstemmingConstants.DATA)
             konsistensavstemmingsdata.apply {
@@ -59,7 +60,7 @@ class KonsistensavstemmingMapper(private val fagsystem: String,
     private fun lagOppdragsdata(utbetalingsoppdrag: Utbetalingsoppdrag): Oppdragsdata {
         return Oppdragsdata().apply {
             fagomradeKode = utbetalingsoppdrag.fagSystem
-            fagsystemId = utbetalingsoppdrag.saksnummer
+            fagsystemId = utbetalingsoppdrag.fagsystemId()
             utbetalingsfrekvens = UtbetalingsfrekvensKode.MÅNEDLIG.kode
             oppdragGjelderId = utbetalingsoppdrag.aktoer
             oppdragGjelderFom = OppdragSkjemaConstants.OPPDRAG_GJELDER_DATO_FOM.format(datoFormatter)
@@ -82,9 +83,9 @@ class KonsistensavstemmingMapper(private val fagsystem: String,
         totalBeløp += utbetalingsperiode.sats.toLong()
         return Oppdragslinje().apply {
             vedtakId = utbetalingsperiode.datoForVedtak.format(datoFormatter)
-            delytelseId = utbetalingsoppdrag.saksnummer + utbetalingsperiode.periodeId
+            delytelseId = utbetalingsoppdrag.fagsystemId() + utbetalingsperiode.periodeId
             utbetalingsperiode.forrigePeriodeId?.let {
-                refDelytelseId = utbetalingsoppdrag.saksnummer + it
+                refDelytelseId = utbetalingsoppdrag.fagsystemId() + it
             }
             klassifikasjonKode = utbetalingsperiode.klassifisering
             vedtakPeriode = Periode().apply {

--- a/src/main/kotlin/no/nav/familie/oppdrag/repository/OppdragLager.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/repository/OppdragLager.kt
@@ -4,6 +4,7 @@ import no.nav.familie.kontrakter.felles.oppdrag.OppdragId
 import no.nav.familie.kontrakter.felles.oppdrag.OppdragStatus
 import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsoppdrag
 import no.nav.familie.kontrakter.felles.oppdrag.behandlingsIdForFørsteUtbetalingsperiode
+import no.nav.familie.oppdrag.common.fagsystemId
 import no.nav.familie.oppdrag.iverksetting.Jaxb
 import no.nav.familie.oppdrag.iverksetting.OppdragMapper
 import no.trygdeetaten.skjema.oppdrag.Mmel
@@ -32,7 +33,7 @@ data class OppdragLager(@Id
         fun lagFraOppdrag(utbetalingsoppdrag: Utbetalingsoppdrag, oppdrag: Oppdrag, versjon: Int = 0): OppdragLager {
             return OppdragLager(personIdent = utbetalingsoppdrag.aktoer,
                                 fagsystem = utbetalingsoppdrag.fagSystem,
-                                fagsakId = utbetalingsoppdrag.saksnummer,
+                                fagsakId = utbetalingsoppdrag.fagsystemId(),
                                 behandlingId = utbetalingsoppdrag.behandlingsIdForFørsteUtbetalingsperiode(),
                                 avstemmingTidspunkt = utbetalingsoppdrag.avstemmingTidspunkt,
                                 utbetalingsoppdrag = utbetalingsoppdrag,

--- a/src/main/kotlin/no/nav/familie/oppdrag/repository/SimuleringLager.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/repository/SimuleringLager.kt
@@ -3,6 +3,7 @@ package no.nav.familie.oppdrag.repository
 import no.nav.familie.kontrakter.felles.objectMapper
 import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsoppdrag
 import no.nav.familie.kontrakter.felles.oppdrag.behandlingsIdForFørsteUtbetalingsperiode
+import no.nav.familie.oppdrag.common.fagsystemId
 import no.nav.familie.oppdrag.iverksetting.Jaxb
 import no.nav.system.os.tjenester.simulerfpservice.simulerfpservicegrensesnitt.SimulerBeregningRequest
 import org.springframework.data.annotation.Id
@@ -26,7 +27,7 @@ data class SimuleringLager(@Id val id: UUID = UUID.randomUUID(),
                           request: SimulerBeregningRequest): SimuleringLager {
             return SimuleringLager(
                     fagsystem = utbetalingsoppdrag.fagSystem,
-                    fagsakId = utbetalingsoppdrag.saksnummer,
+                    fagsakId = utbetalingsoppdrag.fagsystemId(),
                     behandlingId = utbetalingsoppdrag.behandlingsIdForFørsteUtbetalingsperiode(),
                     utbetalingsoppdrag = objectMapper.writeValueAsString(utbetalingsoppdrag),
                     requestXml = Jaxb.tilXml(request = request)

--- a/src/main/kotlin/no/nav/familie/oppdrag/rest/OppdragController.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/rest/OppdragController.kt
@@ -7,6 +7,7 @@ import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsoppdrag
 import no.nav.familie.oppdrag.common.RessursUtils.illegalState
 import no.nav.familie.oppdrag.common.RessursUtils.notFound
 import no.nav.familie.oppdrag.common.RessursUtils.ok
+import no.nav.familie.oppdrag.common.fagsystemId
 import no.nav.familie.oppdrag.iverksetting.OppdragMapper
 import no.nav.familie.oppdrag.service.OppdragService
 import no.nav.security.token.support.core.api.ProtectedWithClaims
@@ -32,7 +33,7 @@ class OppdragController(@Autowired val oppdragService: OppdragService,
             oppdragService.opprettOppdrag(utbetalingsoppdrag, oppdrag, 0)
         }.fold(
                 onFailure = {
-                    illegalState("Klarte ikke sende oppdrag for saksnr ${utbetalingsoppdrag.saksnummer}", it)
+                    illegalState("Klarte ikke sende oppdrag for saksnr ${utbetalingsoppdrag.fagsystemId()}", it)
                 },
                 onSuccess = {
                     ok("Oppdrag sendt OK")
@@ -50,7 +51,7 @@ class OppdragController(@Autowired val oppdragService: OppdragService,
             oppdragService.opprettOppdrag(utbetalingsoppdrag, oppdrag, versjon)
         }.fold(
                 onFailure = {
-                    illegalState("Klarte ikke sende oppdrag for saksnr ${utbetalingsoppdrag.saksnummer}", it)
+                    illegalState("Klarte ikke sende oppdrag for saksnr ${utbetalingsoppdrag.fagsystemId()}", it)
                 },
                 onSuccess = {
                     ok("Oppdrag sendt OK")

--- a/src/main/kotlin/no/nav/familie/oppdrag/rest/SimuleringController.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/rest/SimuleringController.kt
@@ -6,6 +6,7 @@ import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsoppdrag
 import no.nav.familie.kontrakter.felles.simulering.DetaljertSimuleringResultat
 import no.nav.familie.oppdrag.common.RessursUtils.noContent
 import no.nav.familie.oppdrag.common.RessursUtils.ok
+import no.nav.familie.oppdrag.common.fagsystemId
 import no.nav.familie.oppdrag.simulering.SimuleringTjeneste
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import no.nav.system.os.tjenester.simulerfpservice.simulerfpservicegrensesnitt.SimulerBeregningResponse
@@ -27,7 +28,7 @@ class SimuleringController(@Autowired val simuleringTjeneste: SimuleringTjeneste
     @PostMapping(path = ["/etterbetalingsbelop"])
     fun hentEtterbetalingsbeløp(@Valid @RequestBody
                                 utbetalingsoppdrag: Utbetalingsoppdrag): ResponseEntity<Ressurs<RestSimulerResultat>> {
-        LOG.info("Hente simulert etterbetaling for saksnr ${utbetalingsoppdrag.saksnummer}")
+        LOG.info("Hente simulert etterbetaling for saksnr ${utbetalingsoppdrag.fagsystemId()}")
         return ok(simuleringTjeneste.utførSimulering(utbetalingsoppdrag))
     }
 

--- a/src/main/kotlin/no/nav/familie/oppdrag/simulering/SimulerBeregningRequestMapper.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/simulering/SimulerBeregningRequestMapper.kt
@@ -2,6 +2,7 @@ package no.nav.familie.oppdrag.simulering
 
 import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsoppdrag
 import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsperiode
+import no.nav.familie.oppdrag.common.fagsystemId
 import no.nav.familie.oppdrag.iverksetting.*
 import no.nav.system.os.entiteter.typer.simpletypes.FradragTillegg
 import no.nav.system.os.entiteter.typer.simpletypes.KodeStatusLinje
@@ -42,7 +43,7 @@ class SimulerBeregningRequestMapper {
         return fpServiceTypesFactory.createOppdrag().apply {
             kodeEndring = EndringsKode.fromKode(utbetalingsoppdrag.kodeEndring.name).kode
             kodeFagomraade = utbetalingsoppdrag.fagSystem
-            fagsystemId = utbetalingsoppdrag.saksnummer
+            fagsystemId = utbetalingsoppdrag.fagsystemId()
             utbetFrekvens = UtbetalingsfrekvensKode.MÅNEDLIG.kode
             oppdragGjelderId = utbetalingsoppdrag.aktoer
             datoOppdragGjelderFom = OppdragSkjemaConstants.OPPDRAG_GJELDER_DATO_FOM.toString()
@@ -71,12 +72,12 @@ class SimulerBeregningRequestMapper {
             }
             if (!utbetalingsperiode.erEndringPåEksisterendePeriode) {
                 utbetalingsperiode.forrigePeriodeId?.let {
-                    refDelytelseId = utbetalingsoppdrag.saksnummer + it
-                    refFagsystemId = utbetalingsoppdrag.saksnummer
+                    refDelytelseId = utbetalingsoppdrag.fagsystemId() + it
+                    refFagsystemId = utbetalingsoppdrag.fagsystemId()
                 }
             }
             vedtakId = utbetalingsperiode.datoForVedtak.toString()
-            delytelseId = utbetalingsoppdrag.saksnummer + utbetalingsperiode.periodeId
+            delytelseId = utbetalingsoppdrag.fagsystemId() + utbetalingsperiode.periodeId
             kodeKlassifik = utbetalingsperiode.klassifisering
             datoVedtakFom = utbetalingsperiode.vedtakdatoFom.toString()
             datoVedtakTom = utbetalingsperiode.vedtakdatoTom.toString()

--- a/src/main/kotlin/no/nav/familie/oppdrag/simulering/SimuleringTjenesteImpl.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/simulering/SimuleringTjenesteImpl.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import no.nav.familie.kontrakter.felles.oppdrag.RestSimulerResultat
 import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsoppdrag
 import no.nav.familie.kontrakter.felles.simulering.DetaljertSimuleringResultat
+import no.nav.familie.oppdrag.common.fagsystemId
 import no.nav.familie.oppdrag.iverksetting.Jaxb
 import no.nav.familie.oppdrag.repository.SimuleringLager
 import no.nav.familie.oppdrag.repository.SimuleringLagerTjeneste
@@ -36,7 +37,7 @@ class SimuleringTjenesteImpl(@Autowired val simuleringSender: SimuleringSender,
     override fun hentSimulerBeregningResponse(utbetalingsoppdrag: Utbetalingsoppdrag): SimulerBeregningResponse {
         val simulerBeregningRequest = simulerBeregningRequestMapper.tilSimulerBeregningRequest(utbetalingsoppdrag)
 
-        secureLogger.info("Saksnummer: ${utbetalingsoppdrag.saksnummer} : " +
+        secureLogger.info("Saksnummer: ${utbetalingsoppdrag.fagsystemId()} : " +
                           mapper.writerWithDefaultPrettyPrinter().writeValueAsString(simulerBeregningRequest))
 
         return hentSimulerBeregningResponse(simulerBeregningRequest, utbetalingsoppdrag)
@@ -46,7 +47,7 @@ class SimuleringTjenesteImpl(@Autowired val simuleringSender: SimuleringSender,
                                              utbetalingsoppdrag: Utbetalingsoppdrag): SimulerBeregningResponse {
         try {
             val response = simuleringSender.hentSimulerBeregningResponse(simulerBeregningRequest)
-            secureLogger.info("Saksnummer: ${utbetalingsoppdrag.saksnummer} : " +
+            secureLogger.info("Saksnummer: ${utbetalingsoppdrag.fagsystemId()} : " +
                               mapper.writerWithDefaultPrettyPrinter().writeValueAsString(response))
             return response
         } catch (ex: SimulerBeregningFeilUnderBehandling) {
@@ -66,7 +67,7 @@ class SimuleringTjenesteImpl(@Autowired val simuleringSender: SimuleringSender,
     override fun utførSimuleringOghentDetaljertSimuleringResultat(utbetalingsoppdrag: Utbetalingsoppdrag): DetaljertSimuleringResultat? {
         val simulerBeregningRequest = simulerBeregningRequestMapper.tilSimulerBeregningRequest(utbetalingsoppdrag)
 
-        secureLogger.info("Saksnummer: ${utbetalingsoppdrag.saksnummer} : " +
+        secureLogger.info("Saksnummer: ${utbetalingsoppdrag.fagsystemId()} : " +
                           mapper.writerWithDefaultPrettyPrinter().writeValueAsString(simulerBeregningRequest))
 
         val simuleringsLager = SimuleringLager.lagFraOppdrag(utbetalingsoppdrag, simulerBeregningRequest)

--- a/src/test/kotlin/no/nav/familie/oppdrag/common/FagsakIdUtilKtTest.kt
+++ b/src/test/kotlin/no/nav/familie/oppdrag/common/FagsakIdUtilKtTest.kt
@@ -1,0 +1,35 @@
+package no.nav.familie.oppdrag.common
+
+import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsoppdrag
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+
+internal class FagsakIdUtilKtTest {
+
+    private val utbetalingsoppdrag = Utbetalingsoppdrag(kodeEndring = Utbetalingsoppdrag.KodeEndring.NY,
+                                                        fagSystem = "BA",
+                                                        saksnummer = "saksnummer",
+                                                        aktoer = "0",
+                                                        saksbehandlerId = "",
+                                                        avstemmingTidspunkt = LocalDateTime.now(),
+                                                        utbetalingsperiode = emptyList())
+
+    @Test
+    internal fun `skal returnere 0 i prefix hvis det er preprod`() {
+        val utbetalingsoppdrag = utbetalingsoppdrag
+        assertThat(utbetalingsoppdrag.fagsystemId("preprod")).isEqualTo("0saksnummer")
+    }
+
+    @Test
+    internal fun `skal ikke returnere 0 i prefix hvis det er prod`() {
+        val utbetalingsoppdrag = utbetalingsoppdrag
+        assertThat(utbetalingsoppdrag.fagsystemId("prod")).isEqualTo("saksnummer")
+    }
+
+    @Test
+    internal fun `skal ikke returnere 0 i prefix hvis den savner profile`() {
+        val utbetalingsoppdrag = utbetalingsoppdrag
+        assertThat(utbetalingsoppdrag.fagsystemId("")).isEqualTo("saksnummer")
+    }
+}

--- a/src/test/kotlin/no/nav/familie/oppdrag/iverksetting/KontraktTilOppdragTest.kt
+++ b/src/test/kotlin/no/nav/familie/oppdrag/iverksetting/KontraktTilOppdragTest.kt
@@ -3,6 +3,7 @@ package no.nav.familie.oppdrag.iverksetting
 import no.nav.familie.kontrakter.felles.oppdrag.Opphør
 import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsoppdrag
 import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsperiode
+import no.nav.familie.oppdrag.common.fagsystemId
 import no.trygdeetaten.skjema.oppdrag.Oppdrag110
 import no.trygdeetaten.skjema.oppdrag.OppdragsLinje150
 import org.junit.jupiter.api.Assertions
@@ -99,7 +100,7 @@ class KontraktTilOppdragTest {
         Assertions.assertEquals(OppdragSkjemaConstants.KODE_AKSJON, oppdrag110.kodeAksjon)
         Assertions.assertEquals(utbetalingsoppdrag.kodeEndring.name, oppdrag110.kodeEndring.toString())
         Assertions.assertEquals(utbetalingsoppdrag.fagSystem, oppdrag110.kodeFagomraade)
-        Assertions.assertEquals(utbetalingsoppdrag.saksnummer, oppdrag110.fagsystemId)
+        Assertions.assertEquals(utbetalingsoppdrag.fagsystemId(), oppdrag110.fagsystemId)
         Assertions.assertEquals(UtbetalingsfrekvensKode.MÅNEDLIG.kode, oppdrag110.utbetFrekvens)
         Assertions.assertEquals(utbetalingsoppdrag.aktoer, oppdrag110.oppdragGjelderId)
         Assertions.assertEquals(OppdragSkjemaConstants.OPPDRAG_GJELDER_DATO_FOM.toXMLDate(), oppdrag110.datoOppdragGjelderFom)
@@ -116,7 +117,7 @@ class KontraktTilOppdragTest {
         Assertions.assertEquals(if (utbetalingsperiode.erEndringPåEksisterendePeriode) EndringsKode.ENDRING.kode else EndringsKode.NY.kode, oppdragsLinje150.kodeEndringLinje)
         assertOpphør(utbetalingsperiode, oppdragsLinje150)
         Assertions.assertEquals(utbetalingsperiode.datoForVedtak.toString(), oppdragsLinje150.vedtakId)
-        Assertions.assertEquals(utbetalingsoppdrag.saksnummer+utbetalingsperiode.periodeId.toString(), oppdragsLinje150.delytelseId)
+        Assertions.assertEquals(utbetalingsoppdrag.fagsystemId()+utbetalingsperiode.periodeId.toString(), oppdragsLinje150.delytelseId)
         Assertions.assertEquals(utbetalingsperiode.klassifisering, oppdragsLinje150.kodeKlassifik)
         Assertions.assertEquals(utbetalingsperiode.vedtakdatoFom.toXMLDate(), oppdragsLinje150.datoVedtakFom)
         Assertions.assertEquals(utbetalingsperiode.vedtakdatoTom.toXMLDate(), oppdragsLinje150.datoVedtakTom)
@@ -130,7 +131,7 @@ class KontraktTilOppdragTest {
         Assertions.assertEquals(utbetalingsoppdrag.saksbehandlerId, oppdragsLinje150.attestant180[0].attestantId)
         Assertions.assertEquals(utbetalingsperiode.utbetalingsgrad, oppdragsLinje150.grad170.firstOrNull()?.grad?.toInt())
 
-        if (utbetalingsperiode.forrigePeriodeId !== null && !utbetalingsperiode.erEndringPåEksisterendePeriode) Assertions.assertEquals(utbetalingsoppdrag.saksnummer + utbetalingsperiode.forrigePeriodeId.toString(), oppdragsLinje150.refDelytelseId)
+        if (utbetalingsperiode.forrigePeriodeId !== null && !utbetalingsperiode.erEndringPåEksisterendePeriode) Assertions.assertEquals(utbetalingsoppdrag.fagsystemId() + utbetalingsperiode.forrigePeriodeId.toString(), oppdragsLinje150.refDelytelseId)
     }
 
     fun assertOpphør(utbetalingsperiode: Utbetalingsperiode, oppdragsLinje150: OppdragsLinje150) {

--- a/src/test/kotlin/no/nav/familie/oppdrag/konsistensavstemming/KonsistensavstemmingMapperTest.kt
+++ b/src/test/kotlin/no/nav/familie/oppdrag/konsistensavstemming/KonsistensavstemmingMapperTest.kt
@@ -3,6 +3,7 @@ package no.nav.familie.oppdrag.konsistensavstemming
 import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsoppdrag
 import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsperiode
 import no.nav.familie.oppdrag.avstemming.SystemKode
+import no.nav.familie.oppdrag.common.fagsystemId
 import no.nav.familie.oppdrag.iverksetting.OppdragSkjemaConstants
 import no.nav.familie.oppdrag.iverksetting.SatsTypeKode
 import no.nav.familie.oppdrag.iverksetting.UtbetalingsfrekvensKode
@@ -107,7 +108,7 @@ class KonsistensavstemmingMapperTest {
 
     fun assertOppdragsdata(utbetalingsoppdrag: Utbetalingsoppdrag, actual: Oppdragsdata) {
         assertEquals(fagområde, actual.fagomradeKode)
-        assertEquals(utbetalingsoppdrag.saksnummer, actual.fagsystemId)
+        assertEquals(utbetalingsoppdrag.fagsystemId(), actual.fagsystemId)
         assertEquals(UtbetalingsfrekvensKode.MÅNEDLIG.kode, actual.utbetalingsfrekvens)
         assertEquals(utbetalingsoppdrag.aktoer, actual.oppdragGjelderId)
         assertEquals(OppdragSkjemaConstants.OPPDRAG_GJELDER_DATO_FOM.format(datoFormatter), actual.oppdragGjelderFom)


### PR DESCRIPTION
…prod som inneholder de samme saksnummer (fagsakId) som i dev då den vanligtvis er inkrementell

2 ganger i året lastes inn data fra prod i noen miljøer, sånn att eks fagsak id 10 finnes fra prod, og sen når vi sender ett id fra våret system så finnes allerede id 10, då vi har ett inkrementellt nummer i databasen