### PR TITLE
Økonomi returnerer null i responset når man eks simulerer frem i tid.…

### DIFF
--- a/src/main/kotlin/no/nav/familie/oppdrag/rest/SimuleringController.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/rest/SimuleringController.kt
@@ -34,12 +34,7 @@ class SimuleringController(@Autowired val simuleringTjeneste: SimuleringTjeneste
     @PostMapping(path = ["/v1"])
     fun utførSimuleringOgHentResultat(@Valid @RequestBody
                                       utbetalingsoppdrag: Utbetalingsoppdrag): ResponseEntity<Ressurs<DetaljertSimuleringResultat>> {
-        val detaljertSimuleringResultat: DetaljertSimuleringResultat? =
-                simuleringTjeneste.utførSimuleringOghentDetaljertSimuleringResultat(utbetalingsoppdrag)
-        if (detaljertSimuleringResultat != null) {
-            return ok(detaljertSimuleringResultat)
-        }
-        return noContent()
+        return ok(simuleringTjeneste.utførSimuleringOghentDetaljertSimuleringResultat(utbetalingsoppdrag))
     }
 
     //Temporær funksjon som skal brukes for å teste responser fra oppdrag.

--- a/src/main/kotlin/no/nav/familie/oppdrag/simulering/SimuleringTjeneste.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/simulering/SimuleringTjeneste.kt
@@ -8,6 +8,6 @@ import no.nav.system.os.tjenester.simulerfpservice.simulerfpservicegrensesnitt.S
 interface SimuleringTjeneste {
 
     fun utførSimulering(utbetalingsoppdrag: Utbetalingsoppdrag): RestSimulerResultat
-    fun utførSimuleringOghentDetaljertSimuleringResultat(utbetalingsoppdrag: Utbetalingsoppdrag): DetaljertSimuleringResultat?
+    fun utførSimuleringOghentDetaljertSimuleringResultat(utbetalingsoppdrag: Utbetalingsoppdrag): DetaljertSimuleringResultat
     fun hentSimulerBeregningResponse(utbetalingsoppdrag: Utbetalingsoppdrag): SimulerBeregningResponse
 }

--- a/src/main/kotlin/no/nav/familie/oppdrag/simulering/SimuleringTjenesteImpl.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/simulering/SimuleringTjenesteImpl.kt
@@ -60,7 +60,7 @@ class SimuleringTjenesteImpl(@Autowired val simuleringSender: SimuleringSender,
         }
     }
 
-    override fun utførSimuleringOghentDetaljertSimuleringResultat(utbetalingsoppdrag: Utbetalingsoppdrag): DetaljertSimuleringResultat? {
+    override fun utførSimuleringOghentDetaljertSimuleringResultat(utbetalingsoppdrag: Utbetalingsoppdrag): DetaljertSimuleringResultat {
         val simulerBeregningRequest = simulerBeregningRequestMapper.tilSimulerBeregningRequest(utbetalingsoppdrag)
 
         secureLogger.info("Saksnummer: ${utbetalingsoppdrag.saksnummer} : " +
@@ -74,7 +74,7 @@ class SimuleringTjenesteImpl(@Autowired val simuleringSender: SimuleringSender,
         simuleringsLager.responseXml = Jaxb.tilXml(respons)
         simuleringLagerTjeneste.oppdater(simuleringsLager)
 
-        val beregning = respons.response?.simulering ?: return null
+        val beregning = respons.response?.simulering ?: return DetaljertSimuleringResultat(emptyList())
         return simuleringResultatTransformer.mapSimulering(beregning = beregning, utbetalingsoppdrag = utbetalingsoppdrag)
     }
 


### PR DESCRIPTION
… og når økonomi returnerer null er det vel mer motsvarende en tom liste i våret api enn 204.
I tillegg til at noContent støttes dårlig av resterende funksjonalitet i våre felles-bibliotek. Var litt usikker på hvilken løsning jeg skulle gå for først så er åpen for innspill.

BA sin håndtering av dette (returnerer tom liste hvis null)
https://github.com/navikt/familie-ba-sak/blob/master/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringService.kt#L51
https://github.com/navikt/familie-ba-sak/blob/master/src/main/kotlin/no/nav/familie/ba/sak/kjerne/simulering/SimuleringService.kt#L99

Denne returnerer null, hvis jeg tenker blir litt rart då man forventer å få en `Ressurs<noe>` som då er null. Uklart for konsumenten om det er riktig att det skal returnere null eller ikke. Eks 200 og null hadde vært veldig rart, mens 204 og null er mer greit.
https://github.com/navikt/familie-felles/blob/master/http-client/src/main/java/no/nav/familie/http/client/AbstractRestClient.kt#L76