### PR TITLE
Prøvd å forbedre feilhåndtering for simulering

### DIFF
--- a/src/main/kotlin/no/nav/familie/oppdrag/common/SOAPFaultExceptionUtil.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/common/SOAPFaultExceptionUtil.kt
@@ -1,0 +1,15 @@
+package no.nav.familie.oppdrag.common
+
+import org.slf4j.LoggerFactory
+import javax.xml.ws.soap.SOAPFaultException
+
+private val secureLogger = LoggerFactory.getLogger("secureLogger")
+
+fun logSoapFaultException(e: Exception) {
+    if (e is SOAPFaultException) {
+        secureLogger.error("SOAPFaultException -" +
+                           " faultCode=${e.fault.faultCode}" +
+                           " faultString=${e.fault.faultString}"
+        )
+    }
+}

--- a/src/main/kotlin/no/nav/familie/oppdrag/config/ApiExceptionHandler.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/config/ApiExceptionHandler.kt
@@ -31,11 +31,10 @@ class ApiExceptionHandler {
 
     @ExceptionHandler(IntegrasjonException::class)
     fun handleThrowable(feil: IntegrasjonException): ResponseEntity<Ressurs<Nothing>> {
-        secureLogger.error("Feil mot økonomiClienten har oppstått: uri={} data={}", feil.uri, feil.data, feil)
-        logger.error("Feil mot økonomiClienten har oppstått exception=${getMostSpecificCause(feil)}")
+        secureLogger.error("Feil mot ${feil.system} har oppstått", feil)
+        logger.error("Feil mot ${feil.system} har oppstått exception=${getMostSpecificCause(feil)::class}")
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                .body(Ressurs.failure(frontendFeilmelding = feil.message,
-                                      errorMessage = feil.cause?.message))
+                .body(Ressurs.failure(errorMessage = feil.message))
     }
 
 }

--- a/src/main/kotlin/no/nav/familie/oppdrag/config/IntegrasjonException.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/config/IntegrasjonException.kt
@@ -1,8 +1,10 @@
 package no.nav.familie.oppdrag.config
 
-import java.net.URI
+enum class Integrasjonssystem {
+    TILBAKEKREVING,
+    SIMULERING
+}
 
-open class IntegrasjonException(msg: String,
-                                throwable: Throwable? = null,
-                                val uri: URI? = null,
-                                val data: Any? = null) : RuntimeException(msg, throwable)
+open class IntegrasjonException(val system: Integrasjonssystem,
+                                msg: String,
+                                throwable: Throwable? = null) : RuntimeException(msg, throwable)

--- a/src/main/kotlin/no/nav/familie/oppdrag/tilbakekreving/ØkonomiClient.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/tilbakekreving/ØkonomiClient.kt
@@ -1,6 +1,8 @@
 package no.nav.familie.oppdrag.tilbakekreving
 
+import no.nav.familie.oppdrag.common.logSoapFaultException
 import no.nav.familie.oppdrag.config.IntegrasjonException
+import no.nav.familie.oppdrag.config.Integrasjonssystem
 import no.nav.okonomi.tilbakekrevingservice.KravgrunnlagHentDetaljRequest
 import no.nav.okonomi.tilbakekrevingservice.KravgrunnlagHentDetaljResponse
 import no.nav.okonomi.tilbakekrevingservice.TilbakekrevingPortType
@@ -11,14 +13,11 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import java.math.BigInteger
 import java.util.UUID
-import javax.xml.ws.soap.SOAPFaultException
 
 @Service
 class ØkonomiClient(private val økonomiService: TilbakekrevingPortType) {
 
     private val logger: Logger = LoggerFactory.getLogger(this::class.java)
-    private val secureLogger = LoggerFactory.getLogger("secureLogger")
-
 
     fun iverksettVedtak(behandlingId: UUID,
                         tilbakekrevingsvedtakRequest: TilbakekrevingsvedtakRequest): TilbakekrevingsvedtakResponse {
@@ -27,7 +26,8 @@ class ØkonomiClient(private val økonomiService: TilbakekrevingPortType) {
             return økonomiService.tilbakekrevingsvedtak(tilbakekrevingsvedtakRequest)
         } catch (exception: Exception) {
             logSoapFaultException(exception)
-            throw IntegrasjonException(msg = "Noe gikk galt ved iverksetting av tilbakekrevingsbehandling=$behandlingId",
+            throw IntegrasjonException(system = Integrasjonssystem.TILBAKEKREVING,
+                                       msg = "Noe gikk galt ved iverksetting av tilbakekrevingsbehandling=$behandlingId",
                                        throwable = exception)
         }
     }
@@ -40,17 +40,9 @@ class ØkonomiClient(private val økonomiService: TilbakekrevingPortType) {
             return økonomiService.kravgrunnlagHentDetalj(hentKravgrunnlagRequest)
         } catch (exception: Exception) {
             logSoapFaultException(exception)
-            throw IntegrasjonException(msg = "Noe gikk galt ved henting av kravgrunnlag for kravgrunnlagId=$kravgrunnlagId",
+            throw IntegrasjonException(system = Integrasjonssystem.TILBAKEKREVING,
+                                       msg = "Noe gikk galt ved henting av kravgrunnlag for kravgrunnlagId=$kravgrunnlagId",
                                        throwable = exception)
-        }
-    }
-
-    private fun logSoapFaultException(e: Exception) {
-        if (e is SOAPFaultException) {
-            secureLogger.error("SOAPFaultException -" +
-                               " faultCode=${e.fault.faultCode}" +
-                               " faultString=${e.fault.faultString}"
-            )
         }
     }
 


### PR DESCRIPTION
Kaster IntegrasjonException når det feiler mot simulering for å få litt mer lik logging som tilbakekreving, og att feilet logges som error og ikke warning som tidligere.

Slettet også frontendFeilmelding då jeg tenker att vi ikke burde kaste videre frontendFeilmelding mellom system til system.

Koblet til punkt 1 i 
https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Tea-6133
Håndterer denne feilen litt bedre:
https://logs.adeo.no/goto/00d8072b58d22868c3e0dea944901ad4 

Denne ble tidligere logget som warning men blir nå (burde?) logget som error inne i stacktracen til ApiExceptionMapper
```
Feil ved hentSimulering (SimulerBeregningFeilUnderBehandling) source: .... section: CA35-KON, type: null, message: 
OPPDRAGET/FAGSYSTEM-ID finnes ikke fra før, rootCause: Kode ... - SQL      - MQ, rootCause: 2021-09-15T13:47:36
```