### PR TITLE
Bruker 1 servicebrukere for å unngå feil koblet til att cxf gjennbruk…

### DIFF
--- a/src/main/kotlin/no/nav/familie/oppdrag/config/ServiceConfig.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/config/ServiceConfig.kt
@@ -10,8 +10,8 @@ import org.springframework.context.annotation.Configuration
 
 @Configuration
 class ServiceConfig(@Value("\${SECURITYTOKENSERVICE_URL}") private val stsUrl: String,
-                    @Value("\${CREDENTIAL_USERNAME}") private val systemuserUsername: String,
-                    @Value("\${CREDENTIAL_PASSWORD}") private val systemuserPwd: String,
+                    @Value("\${SERVICEUSER_USERNAME}") private val systemuserUsername: String,
+                    @Value("\${SERVICEUSER_PASSWORD}") private val systemuserPwd: String,
                     @Value("\${OPPDRAG_SERVICE_URL}") private val simulerFpServiceUrl: String) {
 
     init {
@@ -19,16 +19,16 @@ class ServiceConfig(@Value("\${SECURITYTOKENSERVICE_URL}") private val stsUrl: S
         System.setProperty("no.nav.modig.security.systemuser.username", systemuserUsername)
         System.setProperty("no.nav.modig.security.systemuser.password", systemuserPwd)
     }
-    
-    @Bean 
-    fun stsConfig(): StsConfig? {
+
+    @Bean
+    fun stsConfig(): StsConfig {
         return StsConfig.builder()
                 .url(stsUrl)
                 .username(systemuserUsername)
                 .password(systemuserPwd)
                 .build()
     }
-    
+
     @Bean
     fun SimulerFpServicePort(): SimulerFpService =
             CXFClient(SimulerFpService::class.java)

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -22,8 +22,6 @@ spring.datasource.password: test
 
 OPPDRAG_SERVICE_URL: #Mockes ut lokalt
 SECURITYTOKENSERVICE_URL: https://localhost:8063/soap/SecurityTokenServiceProvider/
-CREDENTIAL_USERNAME: not-a-real-srvuser
-CREDENTIAL_PASSWORD: not-a-real-pw
 SERVICEUSER_USERNAME: not-a-real-srvuser
 SERVICEUSER_PASSWORD: not-a-real-pw
 AZURE_APP_WELL_KNOWN_URL: "https://login.microsoftonline.com/navq.onmicrosoft.com/v2.0/.well-known/openid-configuration"

--- a/src/main/resources/application-dev_psql_mq.yaml
+++ b/src/main/resources/application-dev_psql_mq.yaml
@@ -22,8 +22,6 @@ spring.datasource.password: ${SPRING_DATASOURCE_PASSWORD_OVERRIDE}
 spring.datasource.driver-class-name: ${SPRING_DATASOURCE_DRIVER_OVERRIDE}
 
 SECURITYTOKENSERVICE_URL: https://localhost:8063/soap/SecurityTokenServiceProvider/
-CREDENTIAL_USERNAME: not-a-real-srvuser
-CREDENTIAL_PASSWORD: not-a-real-pw
 SERVICEUSER_USERNAME: not-a-real-srvuser
 SERVICEUSER_PASSWORD: not-a-real-pw
 OPPDRAG_SERVICE_URL: #Mockes ut lokalt

--- a/src/main/resources/application-e2e.yaml
+++ b/src/main/resources/application-e2e.yaml
@@ -30,8 +30,6 @@ logging:
   config: "classpath:logback-e2e.xml"
 
 SECURITYTOKENSERVICE_URL: https://localhost:8063/soap/SecurityTokenServiceProvider/
-CREDENTIAL_USERNAME: not-a-real-srvuser
-CREDENTIAL_PASSWORD: not-a-real-pw
 SERVICEUSER_USERNAME: not-a-real-srvuser
 SERVICEUSER_PASSWORD: not-a-real-pw
 OPPDRAG_SERVICE_URL: #Mockes ut lokalt


### PR DESCRIPTION
…er cachet consumerId og det er ryddigere med kun 1 servicebrukere i en app

Nå brukes:
SERVICEUSER_USERNAME=srvfamilie-oppdrag
CREDENTIAL_USERNAME=srvfamilie-ks-opps

Etterpå har vi kun
SERVICEUSER_USERNAME=srvfamilie-oppdrag

Vi har 2 ulike stsKlienter, men inne i cxf så caches disse og blir gjennbrukt tvers ulike soapklienter.
Så når vi først gjør 1 kall til simulering så feiler tilbakekreving etterpå.

Hvis vi først gjør et kall til tilbakekreving så feiler simulering etterpå. 

Det er ryddigere hvis vi kun har 1 servicebrukere i oppdrag. Må vente på att TØB har verifisert att de støtter dette i prod, Q1 virker.

https://nav-it.slack.com/archives/C01EH16LAD9/p1647270513424249?thread_ts=1646995979.064909&cid=C01EH16LAD9
https://stackoverflow.com/a/10601916
