### PR TITLE
Kun søke samhandler INST i tss

### DIFF
--- a/src/main/kotlin/no/nav/familie/oppdrag/tss/TssMQClient.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/tss/TssMQClient.kt
@@ -51,6 +51,7 @@ class TssMQClient(@Qualifier("jmsTemplateTss") private val jmsTemplateTss: JmsTe
         val offIdData = objectFactory.createTidOFF1().apply {
             idOff = orgNr
             kodeIdType = "ORG"
+            kodeSamhType = "INST"
         }
         val samhandlerIDataB910Data = objectFactory.createSamhandlerIDataB910Type().apply {
             brukerID = BRUKER_ID


### PR DESCRIPTION
La til parameter for å kun søke på INST samhandlere, slik at f.eks. ikke får med andre samhandlere som SYKH

