### PR TITLE
tar med nytt felt i simuleringPostering erFeilkonto

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <main-class>no.nav.familie.oppdrag.LauncherKt</main-class>
         <common-java-modules.version>2.2022.06.30_06.19-0603b0416483</common-java-modules.version>
         <felles.version>1.20221006150009_46021ed</felles.version>
-        <kontrakter.version>2.0_20221110141047_2049c86</kontrakter.version>
+        <kontrakter.version>2.0_20230126101531_7e94a8f</kontrakter.version>
         <token-validation-spring.version>2.0.5</token-validation-spring.version>
         <jaxb-api.version>2.3.1</jaxb-api.version>
         <jaxb-core.version>3.0.2</jaxb-core.version>

--- a/src/main/kotlin/no/nav/familie/oppdrag/simulering/SimuleringResultatTransformer.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/simulering/SimuleringResultatTransformer.kt
@@ -51,6 +51,7 @@ class SimuleringResultatTransformer {
     ): SimulertPostering {
         return SimulertPostering(
             betalingType = utledBetalingType(detaljer.belop),
+            erFeilkonto = stoppnivaa.isFeilkonto,
             beløp = detaljer.belop,
             fagOmrådeKode = FagOmrådeKode.fraKode(stoppnivaa.kodeFagomraade.trim()), // Todo: fjerne.trim() når TØB har rettet trailing spaces-feilen (jira: TOB-1509)
             fom = parseDato(detaljer.faktiskFom),


### PR DESCRIPTION
For å kunne beregne riktig nytt beløp for perioder som har manuelle korrigeringer postert som feilutbetaling trenger vi å se på om en feilutbetaling er på feilkonto eller ikke. Se formel under for forklaring.

Nytt Beløp = Sum av alle YTEL debit posteringene fra BA/BA Infotrygd - sum av feilutbetaling(hvis finnes) - korrigeringsbeløp(hvor feilkonto=false)
Tidligere Utbetalt Beløp = Sum av alle YTEL kredit posteringene - Sum av alle YTEL debit manuelt posteringene
Manuelt Postering = Sum av alle YTEL manuelt posteringene(både debit og kredit) - Sum av alle FEIL manuelt posteringene
Feilutbetalt Beløp = Sum av alle FEIL posteringene hvor feilkonto er true
Korrigeringsbeløp = Sum av alle FEIL posteringene fra BA/BA Infotrygf hvor feilkonto er false
Resultat = Nytt beløp - Tidligere Utbetalt Beløp + Manuelt postering