### PR TITLE
Kvitteringsmelding kan potensielt inneholde ident, så logger melding kun til securelogg

### DIFF
--- a/src/main/kotlin/no/nav/familie/oppdrag/iverksetting/OppdragMottaker.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/iverksetting/OppdragMottaker.kt
@@ -43,7 +43,8 @@ class OppdragMottaker(
 
         val kvittering = lesKvittering(svarFraOppdrag)
         val oppdragId = kvittering.id
-        LOG.info(
+        LOG.info("Mottatt melding på kvitteringskø for fagsak $oppdragId: Status ${kvittering.status}, se securelogg for beskrivende melding")
+        secureLogger.info(
             "Mottatt melding på kvitteringskø for fagsak $oppdragId: Status ${kvittering.status}, " +
                 "svar ${kvittering.mmel?.beskrMelding ?: "Beskrivende melding ikke satt fra OS"}"
         )


### PR DESCRIPTION
Kvitteringsmelding kan potensielt inneholde ident, så logger melding kun til securelogg