### PR TITLE
Gi tilgang til obo tokens uten å definere opp gyldige grupper i nais.yaml

### DIFF
--- a/app-preprod.yaml
+++ b/app-preprod.yaml
@@ -44,6 +44,7 @@ spec:
   azure:
     application:
       enabled: true
+      allowAllUsers: true
   accessPolicy:
     inbound:
       rules:

--- a/app-prod.yaml
+++ b/app-prod.yaml
@@ -44,6 +44,7 @@ spec:
   azure:
     application:
       enabled: true
+      allowAllUsers: true
   accessPolicy:
     inbound:
       rules:


### PR DESCRIPTION
Dette er samme oppførsel som tidligere. Men nais teamet har endret default verdi for allowAllUsers fra true til false.