### PR TITLE
Støtte for en annen utebetals til enn fnr i konsistensavstemming, slik at man får sendt over tss id

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <main-class>no.nav.familie.oppdrag.LauncherKt</main-class>
         <common-java-modules.version>2.2023.01.10_13.49-81ddc732df3a</common-java-modules.version>
         <felles.version>1.20230117091843_19b020f</felles.version>
-        <kontrakter.version>2.0_20230214140648_f5fa479</kontrakter.version>
+        <kontrakter.version>2.0_20230223121809_a777026</kontrakter.version>
         <token-validation-spring.version>2.0.9</token-validation-spring.version>
         <jaxb-api.version>2.3.1</jaxb-api.version>
         <jaxb-core.version>3.0.2</jaxb-core.version>

--- a/src/test/kotlin/no/nav/familie/oppdrag/konsistensavstemming/KonsistensavstemmingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/oppdrag/konsistensavstemming/KonsistensavstemmingServiceTest.kt
@@ -121,6 +121,38 @@ class KonsistensavstemmingServiceTest {
     }
 
     @Test
+    internal fun `Bruk verdi fra input til å sette utbetalTilId`() {
+        every { oppdragLagerRepository.hentUtbetalingsoppdragForKonsistensavstemming(any(), eq(setOf("1", "2"))) } returns
+            listOf(utbetalingsoppdrag1_1, utbetalingsoppdrag1_2)
+
+        val perioder = listOf(
+            PerioderForBehandling("1", setOf(1), aktiveFødselsnummere[0], "tss-id"),
+            PerioderForBehandling("2", setOf(3), aktiveFødselsnummere[0])
+        )
+        val request = KonsistensavstemmingRequestV2("BA", perioder, LocalDateTime.now())
+
+        konsistensavstemmingService.utførKonsistensavstemming(request, true, true, null)
+
+        val oppdrag = slot<Konsistensavstemmingsdata>()
+        val totalData = slot<Konsistensavstemmingsdata>()
+        verifyOrder {
+            avstemmingSender.sendKonsistensAvstemming(any())
+            avstemmingSender.sendKonsistensAvstemming(capture(oppdrag))
+            avstemmingSender.sendKonsistensAvstemming(capture(totalData))
+            avstemmingSender.sendKonsistensAvstemming(any())
+        }
+
+        assertThat(oppdrag.captured.oppdragsdataListe).hasSize(1)
+        assertThat(oppdrag.captured.oppdragsdataListe[0].oppdragslinjeListe).hasSize(2)
+        assertThat(oppdrag.captured.oppdragsdataListe[0].oppdragGjelderId).isEqualTo(aktiveFødselsnummere[0])
+        assertThat(oppdrag.captured.oppdragsdataListe[0].oppdragslinjeListe[0].utbetalesTilId == "tss-id")
+        assertThat(oppdrag.captured.oppdragsdataListe[0].oppdragslinjeListe[1].utbetalesTilId == aktiveFødselsnummere[0])
+
+        assertThat(totalData.captured.totaldata.totalBelop.toInt()).isEqualTo(322)
+        assertThat(totalData.captured.totaldata.totalAntall.toInt()).isEqualTo(1)
+    }
+
+    @Test
     internal fun `sender hver fagsak i ulike meldinger`() {
         every { oppdragLagerRepository.hentUtbetalingsoppdragForKonsistensavstemming(any(), eq(setOf("1", "3"))) } returns
             listOf(utbetalingsoppdrag1_1, utbetalingsoppdrag2_1)


### PR DESCRIPTION
utbetales til overstyres ved konsistensavstemming til fnr. Støtte for å overstyre med noe annet enn aktivfnr, slik at man får kjørt konsistensavstemming med tss id for institusjon. Hvis periode har utbetalesTil satt ved konsistensavstemming, så bruker man denne verdien i stedet for aktiv fnr"

