### PR TITLE
Lag endepunkt for å hente utbetalingsoppdrag på behandlinger

### DIFF
--- a/src/main/kotlin/no/nav/familie/oppdrag/repository/OppdragLagerRepository.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/repository/OppdragLagerRepository.kt
@@ -14,10 +14,19 @@ interface OppdragLagerRepository {
     fun opprettOppdrag(oppdragLager: OppdragLager, versjon: Int = 0)
     fun oppdaterStatus(oppdragId: OppdragId, oppdragStatus: OppdragStatus, versjon: Int = 0)
     fun oppdaterKvitteringsmelding(oppdragId: OppdragId, kvittering: Mmel, versjon: Int = 0)
-    fun hentIverksettingerForGrensesnittavstemming(fomTidspunkt: LocalDateTime, tomTidspunkt: LocalDateTime, fagOmråde: String): List<OppdragLager>
+    fun hentIverksettingerForGrensesnittavstemming(
+        fomTidspunkt: LocalDateTime,
+        tomTidspunkt: LocalDateTime,
+        fagOmråde: String,
+    ): List<OppdragLager>
 
     fun hentUtbetalingsoppdragForKonsistensavstemming(
         fagsystem: String,
-        behandlingIder: Set<String>
+        behandlingIder: Set<String>,
+    ): List<UtbetalingsoppdragForKonsistensavstemming>
+
+    fun hentSisteUtbetalingsoppdragForFagsaker(
+        fagsystem: String,
+        fagsakIder: Set<String>,
     ): List<UtbetalingsoppdragForKonsistensavstemming>
 }

--- a/src/main/kotlin/no/nav/familie/oppdrag/repository/OppdragLagerRepositoryJdbc.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/repository/OppdragLagerRepositoryJdbc.kt
@@ -173,8 +173,8 @@ class OppdragLagerRepositoryJdbc(
         val sqlSpørring = """
             SELECT fagsak_id, behandling_id, utbetalingsoppdrag
             FROM oppdrag_lager
-            WHERE (fagsak_id, opprettettidspunkt) IN (
-                SELECT fagsak_id, MAX(opprettettidspunkt)
+            WHERE (fagsak_id, opprettet_tidspunkt) IN (
+                SELECT fagsak_id, MAX(opprettet_tidspunkt)
                 FROM oppdrag_lager
                 WHERE fagsystem=:fagsystem and fagsak_id IN (:fagsakIder)
                 GROUP BY fagsak_id

--- a/src/main/kotlin/no/nav/familie/oppdrag/rest/AvstemmingController.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/rest/AvstemmingController.kt
@@ -17,7 +17,6 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.validation.annotation.Validated
-import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -101,10 +100,10 @@ class AvstemmingController(
         )
     }
 
-    @GetMapping("/{fagsystem}/fagsaker/siste-utbetalingsoppdrag")
+    @PostMapping("/{fagsystem}/fagsaker/siste-utbetalingsoppdrag")
     fun hentSisteUtbetalingsoppdragForFagsaker(
-        @RequestParam fagsakIder: Set<String>,
         @PathVariable fagsystem: Fagsystem,
+        @RequestBody fagsakIder: Set<String>,
     ): ResponseEntity<Ressurs<List<UtbetalingsoppdragForKonsistensavstemming>>> =
         ok(konsistensavstemmingService.hentSisteUtbetalingsoppdragForFagsaker(fagsystem.name, fagsakIder))
 

--- a/src/main/kotlin/no/nav/familie/oppdrag/rest/AvstemmingController.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/rest/AvstemmingController.kt
@@ -6,6 +6,7 @@ import no.nav.familie.kontrakter.felles.oppdrag.KonsistensavstemmingRequestV2
 import no.nav.familie.kontrakter.felles.oppdrag.KonsistensavstemmingUtbetalingsoppdrag
 import no.nav.familie.oppdrag.common.RessursUtils.illegalState
 import no.nav.familie.oppdrag.common.RessursUtils.ok
+import no.nav.familie.oppdrag.service.Fagsystem
 import no.nav.familie.oppdrag.service.GrensesnittavstemmingService
 import no.nav.familie.oppdrag.service.KonsistensavstemmingService
 import no.nav.security.token.support.core.api.ProtectedWithClaims
@@ -15,6 +16,8 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -95,6 +98,11 @@ class AvstemmingController(
             onFailure = { illegalState("Konsistensavstemming feilet", it) },
             onSuccess = { ok("Konsistensavstemming sendt ok") }
         )
+    }
+
+    @GetMapping("/{fagsystem}/behandlinger/utbetalingsoppdrag")
+    fun hentBehandligner(@RequestParam behandlingIder: Set<String>, @PathVariable fagsystem: Fagsystem) {
+        konsistensavstemmingService.hentUtbetalingsoppdrag(fagsystem.name, behandlingIder)
     }
 
     companion object {

--- a/src/main/kotlin/no/nav/familie/oppdrag/rest/AvstemmingController.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/rest/AvstemmingController.kt
@@ -101,12 +101,12 @@ class AvstemmingController(
         )
     }
 
-    @GetMapping("/{fagsystem}/behandlinger/utbetalingsoppdrag")
-    fun hentBehandligner(
-        @RequestParam behandlingIder: Set<String>,
-        @PathVariable fagsystem: Fagsystem
+    @GetMapping("/{fagsystem}/fagsaker/siste-utbetalingsoppdrag")
+    fun hentSisteUtbetalingsoppdragForFagsaker(
+        @RequestParam fagsakIder: Set<String>,
+        @PathVariable fagsystem: Fagsystem,
     ): ResponseEntity<Ressurs<List<UtbetalingsoppdragForKonsistensavstemming>>> =
-        ok(konsistensavstemmingService.hentUtbetalingsoppdrag(fagsystem.name, behandlingIder))
+        ok(konsistensavstemmingService.hentSisteUtbetalingsoppdragForFagsaker(fagsystem.name, fagsakIder))
 
     companion object {
 

--- a/src/main/kotlin/no/nav/familie/oppdrag/rest/AvstemmingController.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/rest/AvstemmingController.kt
@@ -6,6 +6,7 @@ import no.nav.familie.kontrakter.felles.oppdrag.KonsistensavstemmingRequestV2
 import no.nav.familie.kontrakter.felles.oppdrag.KonsistensavstemmingUtbetalingsoppdrag
 import no.nav.familie.oppdrag.common.RessursUtils.illegalState
 import no.nav.familie.oppdrag.common.RessursUtils.ok
+import no.nav.familie.oppdrag.repository.UtbetalingsoppdragForKonsistensavstemming
 import no.nav.familie.oppdrag.service.Fagsystem
 import no.nav.familie.oppdrag.service.GrensesnittavstemmingService
 import no.nav.familie.oppdrag.service.KonsistensavstemmingService
@@ -101,9 +102,11 @@ class AvstemmingController(
     }
 
     @GetMapping("/{fagsystem}/behandlinger/utbetalingsoppdrag")
-    fun hentBehandligner(@RequestParam behandlingIder: Set<String>, @PathVariable fagsystem: Fagsystem) {
-        konsistensavstemmingService.hentUtbetalingsoppdrag(fagsystem.name, behandlingIder)
-    }
+    fun hentBehandligner(
+        @RequestParam behandlingIder: Set<String>,
+        @PathVariable fagsystem: Fagsystem
+    ): ResponseEntity<Ressurs<List<UtbetalingsoppdragForKonsistensavstemming>>> =
+        ok(konsistensavstemmingService.hentUtbetalingsoppdrag(fagsystem.name, behandlingIder))
 
     companion object {
 

--- a/src/main/kotlin/no/nav/familie/oppdrag/service/KonsistensavstemmingService.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/service/KonsistensavstemmingService.kt
@@ -74,8 +74,8 @@ class KonsistensavstemmingService(
         LOG.info("Fullført konsistensavstemming for id ${konsistensavstemmingMapper.avstemmingId}")
     }
 
-    fun hentUtbetalingsoppdrag(fagsystem: String, behandlingIder: Set<String>): List<UtbetalingsoppdragForKonsistensavstemming> {
-        return oppdragLagerRepository.hentUtbetalingsoppdragForKonsistensavstemming(fagsystem, behandlingIder)
+    fun hentSisteUtbetalingsoppdragForFagsaker(fagsystem: String, fagsakIder: Set<String>): List<UtbetalingsoppdragForKonsistensavstemming> {
+        return oppdragLagerRepository.hentSisteUtbetalingsoppdragForFagsaker(fagsystem, fagsakIder)
     }
 
     @Transactional

--- a/src/main/kotlin/no/nav/familie/oppdrag/service/KonsistensavstemmingService.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/service/KonsistensavstemmingService.kt
@@ -74,6 +74,10 @@ class KonsistensavstemmingService(
         LOG.info("Fullført konsistensavstemming for id ${konsistensavstemmingMapper.avstemmingId}")
     }
 
+    fun hentUtbetalingsoppdrag(fagsystem: String, behandlingIder: Set<String>): List<UtbetalingsoppdragForKonsistensavstemming> {
+        return oppdragLagerRepository.hentUtbetalingsoppdragForKonsistensavstemming(fagsystem, behandlingIder)
+    }
+
     @Transactional
     fun utførKonsistensavstemming(
         request: KonsistensavstemmingRequestV2,

--- a/src/test/kotlin/no/nav/familie/oppdrag/repository/OppdragLagerRepositoryJdbcTest.kt
+++ b/src/test/kotlin/no/nav/familie/oppdrag/repository/OppdragLagerRepositoryJdbcTest.kt
@@ -198,8 +198,8 @@ internal class OppdragLagerRepositoryJdbcTest {
         val utbetalingsoppdrag1 = TestOppdragMedAvstemmingsdato.lagTestUtbetalingsoppdrag(forrigeMåned, "BA", fagsak = "1")
         val utbetalingsoppdrag2 = TestOppdragMedAvstemmingsdato.lagTestUtbetalingsoppdrag(forrigeMåned.minusDays(1), "BA", fagsak = "2")
 
-        val oppdragLager1 = utbetalingsoppdrag1.somOppdragLager.copy(status = OppdragStatus.KVITTERT_OK)
-        val oppdragLager2 = utbetalingsoppdrag2.somOppdragLager.copy(status = OppdragStatus.KVITTERT_OK)
+        val oppdragLager1 = utbetalingsoppdrag1.somOppdragLager
+        val oppdragLager2 = utbetalingsoppdrag2.somOppdragLager
         oppdragLagerRepository.opprettOppdrag(oppdragLager1)
         oppdragLagerRepository.opprettOppdrag(oppdragLager2)
 

--- a/src/test/kotlin/no/nav/familie/oppdrag/repository/OppdragLagerRepositoryJdbcTest.kt
+++ b/src/test/kotlin/no/nav/familie/oppdrag/repository/OppdragLagerRepositoryJdbcTest.kt
@@ -191,4 +191,23 @@ internal class OppdragLagerRepositoryJdbcTest {
         assertThat(oppdragLagerRepository.hentUtbetalingsoppdragForKonsistensavstemming(baOppdragLager.fagsystem, behandlingIder))
             .hasSize(5000)
     }
+
+    @Test
+    fun `hentSisteUtbetalingsoppdragForFagsaker test spørring går fint`() {
+        val forrigeMåned = LocalDateTime.now().minusMonths(1)
+        val utbetalingsoppdrag1 = TestOppdragMedAvstemmingsdato.lagTestUtbetalingsoppdrag(forrigeMåned, "BA")
+        val utbetalingsoppdrag2 = TestOppdragMedAvstemmingsdato.lagTestUtbetalingsoppdrag(forrigeMåned.minusDays(1), "BA")
+
+        val oppdragLager1 = utbetalingsoppdrag1.somOppdragLager.copy(status = OppdragStatus.KVITTERT_OK)
+        val oppdragLager2 = utbetalingsoppdrag2.somOppdragLager.copy(status = OppdragStatus.KVITTERT_OK)
+        oppdragLagerRepository.opprettOppdrag(oppdragLager1)
+        oppdragLagerRepository.opprettOppdrag(oppdragLager2)
+
+        val hentedeOppdrag = oppdragLagerRepository.hentSisteUtbetalingsoppdragForFagsaker(
+            fagsystem = oppdragLager1.fagsystem,
+            fagsakIder = setOf(oppdragLager1.fagsakId, oppdragLager2.fagsakId),
+        )
+
+        assertThat(hentedeOppdrag.map { it.utbetalingsoppdrag }).containsAll(listOf(utbetalingsoppdrag1, utbetalingsoppdrag2))
+    }
 }

--- a/src/test/kotlin/no/nav/familie/oppdrag/repository/OppdragLagerRepositoryJdbcTest.kt
+++ b/src/test/kotlin/no/nav/familie/oppdrag/repository/OppdragLagerRepositoryJdbcTest.kt
@@ -195,8 +195,8 @@ internal class OppdragLagerRepositoryJdbcTest {
     @Test
     fun `hentSisteUtbetalingsoppdragForFagsaker test spørring går fint`() {
         val forrigeMåned = LocalDateTime.now().minusMonths(1)
-        val utbetalingsoppdrag1 = TestOppdragMedAvstemmingsdato.lagTestUtbetalingsoppdrag(forrigeMåned, "BA")
-        val utbetalingsoppdrag2 = TestOppdragMedAvstemmingsdato.lagTestUtbetalingsoppdrag(forrigeMåned.minusDays(1), "BA")
+        val utbetalingsoppdrag1 = TestOppdragMedAvstemmingsdato.lagTestUtbetalingsoppdrag(forrigeMåned, "BA", fagsak = "1")
+        val utbetalingsoppdrag2 = TestOppdragMedAvstemmingsdato.lagTestUtbetalingsoppdrag(forrigeMåned.minusDays(1), "BA", fagsak = "2")
 
         val oppdragLager1 = utbetalingsoppdrag1.somOppdragLager.copy(status = OppdragStatus.KVITTERT_OK)
         val oppdragLager2 = utbetalingsoppdrag2.somOppdragLager.copy(status = OppdragStatus.KVITTERT_OK)


### PR DESCRIPTION
Gjør det mulig å sende inn en liste av fagsaker og hente ut siste utbetalingsoppdrag per fagsak.

Brukes til å validere at det vi har sendt til økonomi stemmer overens med tilkjent ytelse i Ba-sak