### PR TITLE
Skal kunne resende oppdrag som feilet med ukjent årsak

### DIFF
--- a/src/main/kotlin/no/nav/familie/oppdrag/rest/OppdragController.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/rest/OppdragController.kt
@@ -80,7 +80,7 @@ class OppdragController(
         @Valid @RequestBody
         oppdragId: OppdragId,
     ) {
-        oppdragService.resentOppdrag(oppdragId)
+        oppdragService.resendOppdrag(oppdragId)
     }
 
     @PostMapping(consumes = [MediaType.APPLICATION_JSON_VALUE], path = ["/status"])

--- a/src/main/kotlin/no/nav/familie/oppdrag/rest/OppdragController.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/rest/OppdragController.kt
@@ -75,6 +75,14 @@ class OppdragController(
         )
     }
 
+    @PostMapping("resend")
+    fun resentOppdrag(
+        @Valid @RequestBody
+        oppdragId: OppdragId,
+    ) {
+        oppdragService.resentOppdrag(oppdragId)
+    }
+
     @PostMapping(consumes = [MediaType.APPLICATION_JSON_VALUE], path = ["/status"])
     fun hentStatus(
         @Valid @RequestBody

--- a/src/main/kotlin/no/nav/familie/oppdrag/service/OppdragService.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/service/OppdragService.kt
@@ -8,5 +8,5 @@ import no.trygdeetaten.skjema.oppdrag.Oppdrag
 interface OppdragService {
     fun opprettOppdrag(utbetalingsoppdrag: Utbetalingsoppdrag, oppdrag: Oppdrag, versjon: Int)
     fun hentStatusForOppdrag(oppdragId: OppdragId): OppdragLager
-    fun resentOppdrag(oppdragId: OppdragId)
+    fun resendOppdrag(oppdragId: OppdragId)
 }

--- a/src/main/kotlin/no/nav/familie/oppdrag/service/OppdragService.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/service/OppdragService.kt
@@ -8,4 +8,5 @@ import no.trygdeetaten.skjema.oppdrag.Oppdrag
 interface OppdragService {
     fun opprettOppdrag(utbetalingsoppdrag: Utbetalingsoppdrag, oppdrag: Oppdrag, versjon: Int)
     fun hentStatusForOppdrag(oppdragId: OppdragId): OppdragLager
+    fun resentOppdrag(oppdragId: OppdragId)
 }

--- a/src/main/kotlin/no/nav/familie/oppdrag/service/OppdragServiceE2E.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/service/OppdragServiceE2E.kt
@@ -32,7 +32,7 @@ class OppdragServiceE2E(
         return oppdragLagerRepository.hentOppdrag(oppdragId)
     }
 
-    override fun resentOppdrag(oppdragId: OppdragId) {
+    override fun resendOppdrag(oppdragId: OppdragId) {
         throw NotImplementedError("Ikke implementert")
     }
 

--- a/src/main/kotlin/no/nav/familie/oppdrag/service/OppdragServiceE2E.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/service/OppdragServiceE2E.kt
@@ -32,6 +32,10 @@ class OppdragServiceE2E(
         return oppdragLagerRepository.hentOppdrag(oppdragId)
     }
 
+    override fun resentOppdrag(oppdragId: OppdragId) {
+        throw NotImplementedError("Ikke implementert")
+    }
+
     companion object {
 
         val LOG = LoggerFactory.getLogger(OppdragServiceE2E::class.java)

--- a/src/main/kotlin/no/nav/familie/oppdrag/service/OppdragServiceImpl.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/service/OppdragServiceImpl.kt
@@ -44,8 +44,7 @@ class OppdragServiceImpl(
     override fun resendOppdrag(oppdragId: OppdragId) {
         val oppdrag = oppdragLagerRepository.hentOppdrag(oppdragId)
         if (oppdrag.status != OppdragStatus.KVITTERT_FUNKSJONELL_FEIL) {
-            LOG.info("Kan ikke resende $oppdragId då status=${oppdrag.status}")
-            return
+            throw UnsupportedOperationException("Kan ikke resende $oppdragId då status=${oppdrag.status}")
         }
         LOG.info("Resender $oppdragId")
         val oppdragXml = Jaxb.tilOppdrag(oppdrag.utgåendeOppdrag)

--- a/src/main/kotlin/no/nav/familie/oppdrag/service/OppdragServiceImpl.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/service/OppdragServiceImpl.kt
@@ -1,8 +1,10 @@
 package no.nav.familie.oppdrag.service
 
 import no.nav.familie.kontrakter.felles.oppdrag.OppdragId
+import no.nav.familie.kontrakter.felles.oppdrag.OppdragStatus
 import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsoppdrag
 import no.nav.familie.oppdrag.domene.id
+import no.nav.familie.oppdrag.iverksetting.Jaxb
 import no.nav.familie.oppdrag.iverksetting.OppdragSender
 import no.nav.familie.oppdrag.repository.OppdragLager
 import no.nav.familie.oppdrag.repository.OppdragLagerRepository
@@ -38,7 +40,21 @@ class OppdragServiceImpl(
         return oppdragLagerRepository.hentOppdrag(oppdragId)
     }
 
+    @Transactional(rollbackFor = [Throwable::class])
+    override fun resentOppdrag(oppdragId: OppdragId) {
+        val oppdrag = oppdragLagerRepository.hentOppdrag(oppdragId)
+        if (oppdrag.status != OppdragStatus.KVITTERT_FUNKSJONELL_FEIL) {
+            LOG.info("Kan ikke resende $oppdragId då status=${oppdrag.status}")
+            return
+        }
+        LOG.info("Resender $oppdragId")
+        val oppdragXml = Jaxb.tilOppdrag(oppdrag.utgåendeOppdrag)
+        oppdragLagerRepository.oppdaterStatus(oppdragId, OppdragStatus.LAGT_PÅ_KØ)
+        oppdragSender.sendOppdrag(oppdragXml)
+    }
+
     companion object {
+
         val LOG = LoggerFactory.getLogger(OppdragServiceImpl::class.java)
     }
 }

--- a/src/main/kotlin/no/nav/familie/oppdrag/service/OppdragServiceImpl.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/service/OppdragServiceImpl.kt
@@ -41,7 +41,7 @@ class OppdragServiceImpl(
     }
 
     @Transactional(rollbackFor = [Throwable::class])
-    override fun resentOppdrag(oppdragId: OppdragId) {
+    override fun resendOppdrag(oppdragId: OppdragId) {
         val oppdrag = oppdragLagerRepository.hentOppdrag(oppdragId)
         if (oppdrag.status != OppdragStatus.KVITTERT_FUNKSJONELL_FEIL) {
             LOG.info("Kan ikke resende $oppdragId då status=${oppdrag.status}")


### PR DESCRIPTION
Vi har en situasjon der noen iverksettinger feilet, eller at kvitteringen gir AVVIST_FUNKSJONELL_FEIL som kan være årsaket av div timetouts i oppdrag, så må ha mulighet for å kunne sende de på nytt

https://nav-it.slack.com/archives/C01ESUV8V52/p1686055894183889