### PR TITLE
Batcher grensesnittsavstemming for å unngå å hente opp for mye i minnet

### DIFF
--- a/src/main/kotlin/no/nav/familie/oppdrag/grensesnittavstemming/GrensesnittavstemmingMapper.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/grensesnittavstemming/GrensesnittavstemmingMapper.kt
@@ -4,7 +4,7 @@ import no.nav.familie.kontrakter.felles.oppdrag.OppdragStatus
 import no.nav.familie.oppdrag.avstemming.AvstemmingMapper
 import no.nav.familie.oppdrag.avstemming.AvstemmingMapper.fagområdeTilAvleverendeKomponentKode
 import no.nav.familie.oppdrag.avstemming.SystemKode
-import no.nav.familie.oppdrag.repository.OppdragLager
+import no.nav.familie.oppdrag.repository.OppdragTilAvstemming
 import no.nav.virksomhet.tjenester.avstemming.meldinger.v1.AksjonType
 import no.nav.virksomhet.tjenester.avstemming.meldinger.v1.Aksjonsdata
 import no.nav.virksomhet.tjenester.avstemming.meldinger.v1.AvstemmingType
@@ -45,7 +45,7 @@ class GrensesnittavstemmingMapper(
 
     fun lagSluttmelding() = lagMelding(AksjonType.AVSL)
 
-    fun lagAvstemmingsmeldinger(oppdragsliste: List<OppdragLager>): List<Avstemmingsdata> {
+    fun lagAvstemmingsmeldinger(oppdragsliste: List<OppdragTilAvstemming>): List<Avstemmingsdata> {
         if (oppdragsliste.isEmpty()) error("Kan ikke lage avstemminger med tom liste")
 
         return opprettAvstemmingsdataLister(oppdragsliste)
@@ -71,7 +71,7 @@ class GrensesnittavstemmingMapper(
         }
     }
 
-    private fun opprettAvstemmingsdataLister(oppdragsliste: List<OppdragLager>): List<Avstemmingsdata> {
+    private fun opprettAvstemmingsdataLister(oppdragsliste: List<OppdragTilAvstemming>): List<Avstemmingsdata> {
         return opprettDetaljdata(oppdragsliste).chunked(ANTALL_DETALJER_PER_MELDING).map {
             lagMelding(AksjonType.DATA).apply {
                 this.detalj.addAll(it)
@@ -79,7 +79,7 @@ class GrensesnittavstemmingMapper(
         }
     }
 
-    private fun opprettDetaljdata(oppdragsliste: List<OppdragLager>): List<Detaljdata> {
+    private fun opprettDetaljdata(oppdragsliste: List<OppdragTilAvstemming>): List<Detaljdata> {
         return oppdragsliste.mapNotNull { oppdrag ->
 
             leggTilGrunnlagsinformasjon(oppdrag)
@@ -107,7 +107,7 @@ class GrensesnittavstemmingMapper(
         }
     }
 
-    private fun håndterAvstemmingstidspunkt(oppdrag: OppdragLager) {
+    private fun håndterAvstemmingstidspunkt(oppdrag: OppdragTilAvstemming) {
         val fom = avstemmingstidspunkt.fom
         val tom = avstemmingstidspunkt.tom
         if (fom == null || fom > oppdrag.avstemmingTidspunkt) {
@@ -118,7 +118,7 @@ class GrensesnittavstemmingMapper(
         }
     }
 
-    private fun leggTilGrunnlagsinformasjon(oppdrag: OppdragLager) {
+    private fun leggTilGrunnlagsinformasjon(oppdrag: OppdragTilAvstemming) {
         val satsbeløp = getSatsBeløp(oppdrag)
         when (oppdrag.status) {
             OppdragStatus.LAGT_PÅ_KØ -> {
@@ -143,12 +143,12 @@ class GrensesnittavstemmingMapper(
         }
     }
 
-    private fun leggTilTotalData(oppdrag: OppdragLager) {
+    private fun leggTilTotalData(oppdrag: OppdragTilAvstemming) {
         total.antall++
         total.beløp += getSatsBeløp(oppdrag)
     }
 
-    private fun opprettDetaljType(oppdrag: OppdragLager): DetaljType? =
+    private fun opprettDetaljType(oppdrag: OppdragTilAvstemming): DetaljType? =
         when (oppdrag.status) {
             OppdragStatus.LAGT_PÅ_KØ -> DetaljType.MANG
             OppdragStatus.KVITTERT_MED_MANGLER -> DetaljType.VARS
@@ -197,7 +197,7 @@ class GrensesnittavstemmingMapper(
         }
     }
 
-    private fun getSatsBeløp(oppdrag: OppdragLager): Long =
+    private fun getSatsBeløp(oppdrag: OppdragTilAvstemming): Long =
         oppdrag.utbetalingsoppdrag.utbetalingsperiode.map { it.sats }.reduce(BigDecimal::add).toLong()
 
     private fun getFortegn(satsbeløp: Long): Fortegn {

--- a/src/main/kotlin/no/nav/familie/oppdrag/grensesnittavstemming/GrensesnittavstemmingMapper.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/grensesnittavstemming/GrensesnittavstemmingMapper.kt
@@ -179,21 +179,21 @@ class GrensesnittavstemmingMapper(
 
     private fun opprettGrunnlagsData(): Grunnlagsdata {
         return Grunnlagsdata().apply {
-            this.godkjentAntall = grunnlagsdata.godkjentAntall
-            this.godkjentBelop = BigDecimal.valueOf(grunnlagsdata.godkjentBelop)
-            this.godkjentFortegn = getFortegn(grunnlagsdata.godkjentBelop)
+            godkjentAntall = grunnlagsdata.godkjentAntall
+            godkjentBelop = BigDecimal.valueOf(grunnlagsdata.godkjentBelop)
+            godkjentFortegn = getFortegn(grunnlagsdata.godkjentBelop)
 
-            this.varselAntall = varselAntall
-            this.varselBelop = BigDecimal.valueOf(grunnlagsdata.varselBelop)
-            this.varselFortegn = getFortegn(grunnlagsdata.varselBelop)
+            varselAntall = grunnlagsdata.varselAntall
+            varselBelop = BigDecimal.valueOf(grunnlagsdata.varselBelop)
+            varselFortegn = getFortegn(grunnlagsdata.varselBelop)
 
-            this.manglerAntall = manglerAntall
-            this.manglerBelop = BigDecimal.valueOf(grunnlagsdata.manglerBelop)
-            this.manglerFortegn = getFortegn(grunnlagsdata.manglerBelop)
+            manglerAntall = grunnlagsdata.manglerAntall
+            manglerBelop = BigDecimal.valueOf(grunnlagsdata.manglerBelop)
+            manglerFortegn = getFortegn(grunnlagsdata.manglerBelop)
 
-            this.avvistAntall = avvistAntall
-            this.avvistBelop = BigDecimal.valueOf(grunnlagsdata.avvistBelop)
-            this.avvistFortegn = getFortegn(grunnlagsdata.avvistBelop)
+            avvistAntall = grunnlagsdata.avvistAntall
+            avvistBelop = BigDecimal.valueOf(grunnlagsdata.avvistBelop)
+            avvistFortegn = getFortegn(grunnlagsdata.avvistBelop)
         }
     }
 

--- a/src/main/kotlin/no/nav/familie/oppdrag/grensesnittavstemming/GrensesnittavstemmingMapper.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/grensesnittavstemming/GrensesnittavstemmingMapper.kt
@@ -22,38 +22,33 @@ import java.time.format.DateTimeFormatter
 import java.util.UUID
 
 class GrensesnittavstemmingMapper(
-    private val oppdragsliste: List<OppdragLager>,
     private val fagområde: String,
     private val fom: LocalDateTime,
     private val tom: LocalDateTime,
 ) {
+
     private val ANTALL_DETALJER_PER_MELDING = 70
     private val tidspunktFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd-HH.mm.ss.SSSSSS")
     val avstemmingId = AvstemmingMapper.encodeUUIDBase64(UUID.randomUUID())
 
-    fun lagAvstemmingsmeldinger(): List<Avstemmingsdata> {
-        if (oppdragsliste.isEmpty()) {
-            return emptyList()
-        } else {
-            return (listOf(lagStartmelding()) + lagDatameldinger() + listOf(lagSluttmelding()))
-        }
+    private val grunnlagsdata = Grunnlag()
+    private val total = Total()
+    private val avstemmingstidspunkt = Avstemmingstidspunkt()
+
+    fun lagStartmelding() = lagMelding(AksjonType.START)
+
+    fun lagTotalMelding() = lagMelding(AksjonType.DATA).apply {
+        this.total = opprettTotalData()
+        this.periode = opprettPeriodeData()
+        this.grunnlag = opprettGrunnlagsData()
     }
 
-    private fun lagStartmelding() = lagMelding(AksjonType.START)
+    fun lagSluttmelding() = lagMelding(AksjonType.AVSL)
 
-    private fun lagSluttmelding() = lagMelding(AksjonType.AVSL)
+    fun lagAvstemmingsmeldinger(oppdragsliste: List<OppdragLager>): List<Avstemmingsdata> {
+        if (oppdragsliste.isEmpty()) error("Kan ikke lage avstemminger med tom liste")
 
-    private fun lagDatameldinger(): List<Avstemmingsdata> {
-        val detaljMeldinger = opprettAvstemmingsdataLister()
-
-        val avstemmingsDataLister = if (detaljMeldinger.isNotEmpty()) detaljMeldinger else listOf(lagMelding(AksjonType.DATA))
-        avstemmingsDataLister.first().apply {
-            this.total = opprettTotalData()
-            this.periode = opprettPeriodeData()
-            this.grunnlag = opprettGrunnlagsData()
-        }
-
-        return avstemmingsDataLister
+        return opprettAvstemmingsdataLister(oppdragsliste)
     }
 
     private fun lagMelding(aksjonType: AksjonType): Avstemmingsdata =
@@ -76,16 +71,21 @@ class GrensesnittavstemmingMapper(
         }
     }
 
-    private fun opprettAvstemmingsdataLister(): List<Avstemmingsdata> {
-        return opprettDetaljdata().chunked(ANTALL_DETALJER_PER_MELDING).map {
+    private fun opprettAvstemmingsdataLister(oppdragsliste: List<OppdragLager>): List<Avstemmingsdata> {
+        return opprettDetaljdata(oppdragsliste).chunked(ANTALL_DETALJER_PER_MELDING).map {
             lagMelding(AksjonType.DATA).apply {
                 this.detalj.addAll(it)
             }
         }
     }
 
-    private fun opprettDetaljdata(): List<Detaljdata> {
+    private fun opprettDetaljdata(oppdragsliste: List<OppdragLager>): List<Detaljdata> {
         return oppdragsliste.mapNotNull { oppdrag ->
+
+            leggTilGrunnlagsinformasjon(oppdrag)
+            leggTilTotalData(oppdrag)
+            håndterAvstemmingstidspunkt(oppdrag)
+
             val detaljType = opprettDetaljType(oppdrag)
             if (detaljType != null) {
                 val utbetalingsoppdrag = oppdrag.utbetalingsoppdrag
@@ -107,6 +107,47 @@ class GrensesnittavstemmingMapper(
         }
     }
 
+    private fun håndterAvstemmingstidspunkt(oppdrag: OppdragLager) {
+        val fom = avstemmingstidspunkt.fom
+        val tom = avstemmingstidspunkt.tom
+        if (fom == null || fom > oppdrag.avstemmingTidspunkt) {
+            avstemmingstidspunkt.fom = oppdrag.avstemmingTidspunkt
+        }
+        if (tom == null || tom > oppdrag.avstemmingTidspunkt) {
+            avstemmingstidspunkt.tom = oppdrag.avstemmingTidspunkt
+        }
+    }
+
+    private fun leggTilGrunnlagsinformasjon(oppdrag: OppdragLager) {
+        val satsbeløp = getSatsBeløp(oppdrag)
+        when (oppdrag.status) {
+            OppdragStatus.LAGT_PÅ_KØ -> {
+                grunnlagsdata.manglerBelop += satsbeløp
+                grunnlagsdata.manglerAntall++
+            }
+
+            OppdragStatus.KVITTERT_OK -> {
+                grunnlagsdata.godkjentBelop += satsbeløp
+                grunnlagsdata.godkjentAntall++
+            }
+
+            OppdragStatus.KVITTERT_MED_MANGLER -> {
+                grunnlagsdata.varselBelop += satsbeløp
+                grunnlagsdata.varselAntall++
+            }
+
+            else -> {
+                grunnlagsdata.avvistBelop += satsbeløp
+                grunnlagsdata.avvistAntall++
+            }
+        }
+    }
+
+    private fun leggTilTotalData(oppdrag: OppdragLager) {
+        total.antall++
+        total.beløp += getSatsBeløp(oppdrag)
+    }
+
     private fun opprettDetaljType(oppdrag: OppdragLager): DetaljType? =
         when (oppdrag.status) {
             OppdragStatus.LAGT_PÅ_KØ -> DetaljType.MANG
@@ -118,69 +159,41 @@ class GrensesnittavstemmingMapper(
         }
 
     private fun opprettTotalData(): Totaldata {
-        val totalBeløp = oppdragsliste.map { getSatsBeløp(it) }.sum()
         return Totaldata().apply {
-            this.totalAntall = oppdragsliste.size
-            this.totalBelop = BigDecimal.valueOf(totalBeløp)
-            this.fortegn = getFortegn(totalBeløp)
+            this.totalAntall = total.antall
+            this.totalBelop = BigDecimal.valueOf(total.beløp)
+            this.fortegn = getFortegn(total.beløp)
         }
     }
 
     private fun opprettPeriodeData(): Periodedata {
+        val fom = avstemmingstidspunkt.fom
+            ?: error("Mangler avstemmingstidspunkt::fom, vi skal ikke opprette meldinger hvis listen med oppdrag er tom")
+        val tom = avstemmingstidspunkt.tom
+            ?: error("Mangler avstemmingstidspunkt::tom, vi skal ikke opprette meldinger hvis listen med oppdrag er tom")
         return Periodedata().apply {
-            this.datoAvstemtFom = formaterTilPeriodedataFormat(getLavesteAvstemmingstidspunkt().format(tidspunktFormatter))
-            this.datoAvstemtTom = formaterTilPeriodedataFormat(getHøyesteAvstemmingstidspunkt().format(tidspunktFormatter))
+            this.datoAvstemtFom = formaterTilPeriodedataFormat(fom.format(tidspunktFormatter))
+            this.datoAvstemtTom = formaterTilPeriodedataFormat(tom.format(tidspunktFormatter))
         }
     }
 
     private fun opprettGrunnlagsData(): Grunnlagsdata {
-        var godkjentAntall = 0
-        var godkjentBelop = 0L
-        var varselAntall = 0
-        var varselBelop = 0L
-        var avvistAntall = 0
-        var avvistBelop = 0L
-        var manglerAntall = 0
-        var manglerBelop = 0L
-
-        for (oppdrag in oppdragsliste) {
-            val satsbeløp = getSatsBeløp(oppdrag)
-            when (oppdrag.status) {
-                OppdragStatus.LAGT_PÅ_KØ -> {
-                    manglerBelop += satsbeløp
-                    manglerAntall++
-                }
-                OppdragStatus.KVITTERT_OK -> {
-                    godkjentBelop += satsbeløp
-                    godkjentAntall++
-                }
-                OppdragStatus.KVITTERT_MED_MANGLER -> {
-                    varselBelop += satsbeløp
-                    varselAntall++
-                }
-                else -> {
-                    avvistBelop += satsbeløp
-                    avvistAntall++
-                }
-            }
-        }
-
         return Grunnlagsdata().apply {
-            this.godkjentAntall = godkjentAntall
-            this.godkjentBelop = BigDecimal.valueOf(godkjentBelop)
-            this.godkjentFortegn = getFortegn(godkjentBelop)
+            this.godkjentAntall = grunnlagsdata.godkjentAntall
+            this.godkjentBelop = BigDecimal.valueOf(grunnlagsdata.godkjentBelop)
+            this.godkjentFortegn = getFortegn(grunnlagsdata.godkjentBelop)
 
             this.varselAntall = varselAntall
-            this.varselBelop = BigDecimal.valueOf(varselBelop)
-            this.varselFortegn = getFortegn(varselBelop)
+            this.varselBelop = BigDecimal.valueOf(grunnlagsdata.varselBelop)
+            this.varselFortegn = getFortegn(grunnlagsdata.varselBelop)
 
             this.manglerAntall = manglerAntall
-            this.manglerBelop = BigDecimal.valueOf(manglerBelop)
-            this.manglerFortegn = getFortegn(manglerBelop)
+            this.manglerBelop = BigDecimal.valueOf(grunnlagsdata.manglerBelop)
+            this.manglerFortegn = getFortegn(grunnlagsdata.manglerBelop)
 
             this.avvistAntall = avvistAntall
-            this.avvistBelop = BigDecimal.valueOf(avvistBelop)
-            this.avvistFortegn = getFortegn(avvistBelop)
+            this.avvistBelop = BigDecimal.valueOf(grunnlagsdata.avvistBelop)
+            this.avvistFortegn = getFortegn(grunnlagsdata.avvistBelop)
         }
     }
 
@@ -191,18 +204,28 @@ class GrensesnittavstemmingMapper(
         return if (satsbeløp >= 0) Fortegn.T else Fortegn.F
     }
 
-    private fun getHøyesteAvstemmingstidspunkt(): LocalDateTime {
-        return sortertAvstemmingstidspunkt().first()
-    }
-
-    private fun getLavesteAvstemmingstidspunkt(): LocalDateTime {
-        return sortertAvstemmingstidspunkt().last()
-    }
-
-    private fun sortertAvstemmingstidspunkt() =
-        oppdragsliste.map(OppdragLager::avstemmingTidspunkt).sortedDescending()
-
     private fun formaterTilPeriodedataFormat(stringTimestamp: String): String =
         LocalDateTime.parse(stringTimestamp, tidspunktFormatter)
             .format(DateTimeFormatter.ofPattern("yyyyMMddHH"))
 }
+
+private data class Grunnlag(
+    var godkjentAntall: Int = 0,
+    var godkjentBelop: Long = 0L,
+    var varselAntall: Int = 0,
+    var varselBelop: Long = 0L,
+    var avvistAntall: Int = 0,
+    var avvistBelop: Long = 0L,
+    var manglerAntall: Int = 0,
+    var manglerBelop: Long = 0L,
+)
+
+data class Total(
+    var antall: Int = 0,
+    var beløp: Long = 0L,
+)
+
+data class Avstemmingstidspunkt(
+    var fom: LocalDateTime? = null,
+    var tom: LocalDateTime? = null,
+)

--- a/src/main/kotlin/no/nav/familie/oppdrag/grensesnittavstemming/GrensesnittavstemmingMapper.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/grensesnittavstemming/GrensesnittavstemmingMapper.kt
@@ -113,7 +113,7 @@ class GrensesnittavstemmingMapper(
         if (fom == null || fom > oppdrag.avstemmingTidspunkt) {
             avstemmingstidspunkt.fom = oppdrag.avstemmingTidspunkt
         }
-        if (tom == null || tom > oppdrag.avstemmingTidspunkt) {
+        if (tom == null || tom < oppdrag.avstemmingTidspunkt) {
             avstemmingstidspunkt.tom = oppdrag.avstemmingTidspunkt
         }
     }

--- a/src/main/kotlin/no/nav/familie/oppdrag/repository/OppdragLager.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/repository/OppdragLager.kt
@@ -5,7 +5,6 @@ import no.nav.familie.kontrakter.felles.oppdrag.OppdragStatus
 import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsoppdrag
 import no.nav.familie.kontrakter.felles.oppdrag.behandlingsIdForFørsteUtbetalingsperiode
 import no.nav.familie.oppdrag.iverksetting.Jaxb
-import no.nav.familie.oppdrag.iverksetting.OppdragMapper
 import no.trygdeetaten.skjema.oppdrag.Mmel
 import no.trygdeetaten.skjema.oppdrag.Oppdrag
 import org.springframework.data.annotation.Id
@@ -47,19 +46,6 @@ data class OppdragLager(
         }
     }
 }
-
-fun Utbetalingsoppdrag.somOppdragLagerMedVersjon(versjon: Int): OppdragLager {
-    val tilOppdrag110 = OppdragMapper().tilOppdrag110(this)
-    val oppdrag = OppdragMapper().tilOppdrag(tilOppdrag110)
-    return OppdragLager.lagFraOppdrag(this, oppdrag, versjon)
-}
-
-val Utbetalingsoppdrag.somOppdragLager: OppdragLager
-    get() {
-        val tilOppdrag110 = OppdragMapper().tilOppdrag110(this)
-        val oppdrag = OppdragMapper().tilOppdrag(tilOppdrag110)
-        return OppdragLager.lagFraOppdrag(this, oppdrag)
-    }
 
 val OppdragLager.id: OppdragId
     get() {

--- a/src/main/kotlin/no/nav/familie/oppdrag/repository/OppdragLagerRepository.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/repository/OppdragLagerRepository.kt
@@ -18,6 +18,8 @@ interface OppdragLagerRepository {
         fomTidspunkt: LocalDateTime,
         tomTidspunkt: LocalDateTime,
         fagOmråde: String,
+        antall: Int,
+        page: Int,
     ): List<OppdragLager>
 
     fun hentUtbetalingsoppdragForKonsistensavstemming(

--- a/src/main/kotlin/no/nav/familie/oppdrag/repository/OppdragLagerRepository.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/repository/OppdragLagerRepository.kt
@@ -20,7 +20,7 @@ interface OppdragLagerRepository {
         fagOmråde: String,
         antall: Int,
         page: Int,
-    ): List<OppdragLager>
+    ): List<OppdragTilAvstemming>
 
     fun hentUtbetalingsoppdragForKonsistensavstemming(
         fagsystem: String,

--- a/src/main/kotlin/no/nav/familie/oppdrag/repository/OppdragLagerRepositoryJdbc.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/repository/OppdragLagerRepositoryJdbc.kt
@@ -108,15 +108,18 @@ class OppdragLagerRepositoryJdbc(
         val hentStatement = """
             SELECT 
             status, opprettet_tidspunkt, person_ident, fagsak_id, behandling_id, fagsystem, avstemming_tidspunkt, utbetalingsoppdrag, kvitteringsmelding
-            FROM oppdrag_lager WHERE avstemming_tidspunkt >= ? AND avstemming_tidspunkt < ? AND fagsystem = ? 
-            ORDER BY behandling_id ASC OFFSET ? LIMIT ?
+            FROM oppdrag_lager 
+            WHERE avstemming_tidspunkt >= :fomTidspunkt AND avstemming_tidspunkt < :tomTidspunkt AND fagsystem = :fagsystem 
+            ORDER BY behandling_id ASC OFFSET :offset LIMIT :limit
             """
+        val values = MapSqlParameterSource()
+            .addValue("fomTidspunkt", fomTidspunkt)
+            .addValue("tomTidspunkt", tomTidspunkt)
+            .addValue("fagsystem", fagOmråde)
+            .addValue("offset", page * antall)
+            .addValue("limit", antall)
 
-        return jdbcTemplate.query(
-            hentStatement,
-            OppdragTilAvstemmingRowMapper,
-            *arrayOf(fomTidspunkt, tomTidspunkt, fagOmråde, page * antall, antall),
-        )
+        return namedParameterJdbcTemplate.query(hentStatement, values, OppdragTilAvstemmingRowMapper)
     }
 
     override fun hentUtbetalingsoppdrag(oppdragId: OppdragId, versjon: Int): Utbetalingsoppdrag {

--- a/src/main/kotlin/no/nav/familie/oppdrag/repository/OppdragLagerRepositoryJdbc.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/repository/OppdragLagerRepositoryJdbc.kt
@@ -104,15 +104,18 @@ class OppdragLagerRepositoryJdbc(
         fagOmråde: String,
         antall: Int,
         page: Int,
-    ): List<OppdragLager> {
-        val hentStatement =
-            "SELECT * FROM oppdrag_lager WHERE avstemming_tidspunkt >= ? AND avstemming_tidspunkt < ? AND fagsystem = ?" +
-                " ORDER BY behandling_id ASC OFFSET ? LIMIT ?"
+    ): List<OppdragTilAvstemming> {
+        val hentStatement = """
+            SELECT 
+            status, opprettet_tidspunkt, person_ident, fagsak_id, behandling_id, fagsystem, avstemming_tidspunkt, utbetalingsoppdrag, kvitteringsmelding
+            FROM oppdrag_lager WHERE avstemming_tidspunkt >= ? AND avstemming_tidspunkt < ? AND fagsystem = ? 
+            ORDER BY behandling_id ASC OFFSET ? LIMIT ?
+            """
 
         return jdbcTemplate.query(
             hentStatement,
-            arrayOf(fomTidspunkt, tomTidspunkt, fagOmråde, page * antall, antall),
-            OppdragLagerRowMapper(),
+            OppdragTilAvstemmingRowMapper,
+            *arrayOf(fomTidspunkt, tomTidspunkt, fagOmråde, page * antall, antall),
         )
     }
 

--- a/src/main/kotlin/no/nav/familie/oppdrag/repository/OppdragLagerRepositoryJdbc.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/repository/OppdragLagerRepositoryJdbc.kt
@@ -108,11 +108,11 @@ class OppdragLagerRepositoryJdbc(
     ): List<OppdragLager> {
         val hentStatement =
             "SELECT * FROM oppdrag_lager WHERE avstemming_tidspunkt >= ? AND avstemming_tidspunkt < ? AND fagsystem = ?" +
-                " ORDER BY behandling_id OFFSET ? LIMIT 10000"
+                " ORDER BY behandling_id ASC OFFSET ? LIMIT ?"
 
         return jdbcTemplate.query(
             hentStatement,
-            arrayOf(fomTidspunkt, tomTidspunkt, fagOmråde, page),
+            arrayOf(fomTidspunkt, tomTidspunkt, fagOmråde, page * antall, antall),
             OppdragLagerRowMapper(),
         )
     }

--- a/src/main/kotlin/no/nav/familie/oppdrag/repository/OppdragLagerRepositoryJdbc.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/repository/OppdragLagerRepositoryJdbc.kt
@@ -103,13 +103,16 @@ class OppdragLagerRepositoryJdbc(
         fomTidspunkt: LocalDateTime,
         tomTidspunkt: LocalDateTime,
         fagOmråde: String,
+        antall: Int,
+        page: Int,
     ): List<OppdragLager> {
         val hentStatement =
-            "SELECT * FROM oppdrag_lager WHERE avstemming_tidspunkt >= ? AND avstemming_tidspunkt < ? AND fagsystem = ?"
+            "SELECT * FROM oppdrag_lager WHERE avstemming_tidspunkt >= ? AND avstemming_tidspunkt < ? AND fagsystem = ?" +
+                " ORDER BY behandling_id OFFSET ? LIMIT 10000"
 
         return jdbcTemplate.query(
             hentStatement,
-            arrayOf(fomTidspunkt, tomTidspunkt, fagOmråde),
+            arrayOf(fomTidspunkt, tomTidspunkt, fagOmråde, page),
             OppdragLagerRowMapper(),
         )
     }

--- a/src/main/kotlin/no/nav/familie/oppdrag/repository/OppdragLagerRepositoryJdbc.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/repository/OppdragLagerRepositoryJdbc.kt
@@ -15,7 +15,6 @@ import org.springframework.stereotype.Repository
 import java.sql.ResultSet
 import java.time.LocalDateTime
 import java.util.UUID
-import kotlin.NoSuchElementException
 
 @Repository
 class OppdragLagerRepositoryJdbc(
@@ -203,21 +202,20 @@ class OppdragLagerRepositoryJdbc(
 
 class OppdragLagerRowMapper : RowMapper<OppdragLager> {
 
-    override fun mapRow(resultSet: ResultSet, rowNumbers: Int): OppdragLager? {
-        val kvittering = resultSet.getString(10)
+    override fun mapRow(resultSet: ResultSet, rowNumbers: Int): OppdragLager {
         return OppdragLager(
-            UUID.fromString(resultSet.getString(12) ?: UUID.randomUUID().toString()),
-            resultSet.getString(7),
-            resultSet.getString(4),
-            resultSet.getString(5),
-            resultSet.getString(6),
-            objectMapper.readValue(resultSet.getString(9)),
-            resultSet.getString(1),
-            OppdragStatus.valueOf(resultSet.getString(2)),
-            resultSet.getTimestamp(8).toLocalDateTime(),
-            resultSet.getTimestamp(3).toLocalDateTime(),
-            if (kvittering == null) null else objectMapper.readValue(kvittering),
-            resultSet.getInt(11),
+            uuid = UUID.fromString(resultSet.getString("id") ?: UUID.randomUUID().toString()),
+            fagsystem = resultSet.getString("fagsystem"),
+            personIdent = resultSet.getString("person_ident"),
+            fagsakId = resultSet.getString("fagsak_id"),
+            behandlingId = resultSet.getString("behandling_id"),
+            utbetalingsoppdrag = objectMapper.readValue(resultSet.getString("utbetalingsoppdrag")),
+            utgåendeOppdrag = resultSet.getString("utgaaende_oppdrag"),
+            status = OppdragStatus.valueOf(resultSet.getString("status")),
+            avstemmingTidspunkt = resultSet.getTimestamp("avstemming_tidspunkt").toLocalDateTime(),
+            opprettetTidspunkt = resultSet.getTimestamp("opprettet_tidspunkt").toLocalDateTime(),
+            kvitteringsmelding = resultSet.getString("kvitteringsmelding")?.let { objectMapper.readValue(it) },
+            versjon = resultSet.getInt("versjon"),
         )
     }
 }

--- a/src/main/kotlin/no/nav/familie/oppdrag/repository/OppdragTilAvstemming.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/repository/OppdragTilAvstemming.kt
@@ -1,0 +1,39 @@
+package no.nav.familie.oppdrag.repository
+
+import com.fasterxml.jackson.module.kotlin.readValue
+import no.nav.familie.kontrakter.felles.objectMapper
+import no.nav.familie.kontrakter.felles.oppdrag.OppdragStatus
+import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsoppdrag
+import no.trygdeetaten.skjema.oppdrag.Mmel
+import org.springframework.jdbc.core.RowMapper
+import java.sql.ResultSet
+import java.time.LocalDateTime
+
+data class OppdragTilAvstemming(
+    val fagsystem: String,
+    val personIdent: String,
+    val fagsakId: String,
+    val behandlingId: String,
+    val utbetalingsoppdrag: Utbetalingsoppdrag,
+    var status: OppdragStatus = OppdragStatus.LAGT_PÅ_KØ,
+    val avstemmingTidspunkt: LocalDateTime,
+    val opprettetTidspunkt: LocalDateTime,
+    val kvitteringsmelding: Mmel?,
+)
+
+object OppdragTilAvstemmingRowMapper : RowMapper<OppdragTilAvstemming> {
+
+    override fun mapRow(resultSet: ResultSet, rowNumbers: Int): OppdragTilAvstemming {
+        return OppdragTilAvstemming(
+            fagsystem = resultSet.getString("fagsystem"),
+            personIdent = resultSet.getString("person_ident"),
+            fagsakId = resultSet.getString("fagsak_id"),
+            behandlingId = resultSet.getString("behandling_id"),
+            utbetalingsoppdrag = objectMapper.readValue(resultSet.getString("utbetalingsoppdrag")),
+            status = OppdragStatus.valueOf(resultSet.getString("status")),
+            avstemmingTidspunkt = resultSet.getTimestamp("avstemming_tidspunkt").toLocalDateTime(),
+            opprettetTidspunkt = resultSet.getTimestamp("opprettet_tidspunkt").toLocalDateTime(),
+            kvitteringsmelding = resultSet.getString("kvitteringsmelding")?.let { objectMapper.readValue(it) },
+        )
+    }
+}

--- a/src/main/kotlin/no/nav/familie/oppdrag/service/GrensesnittavstemmingService.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/service/GrensesnittavstemmingService.kt
@@ -17,7 +17,7 @@ import java.time.LocalDateTime
 class GrensesnittavstemmingService(
     private val avstemmingSender: AvstemmingSender,
     private val oppdragLagerRepository: OppdragLagerRepository,
-    @Value("\${grensesnitt.antall:1000}") private val antall: Int,
+    @Value("\${grensesnitt.antall:7000}") private val antall: Int,
 ) {
 
     private var countere: MutableMap<String, Map<String, Counter>> = HashMap()

--- a/src/main/kotlin/no/nav/familie/oppdrag/service/GrensesnittavstemmingService.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/service/GrensesnittavstemmingService.kt
@@ -43,9 +43,8 @@ class GrensesnittavstemmingService(
         avstemmingSender.sendGrensesnittAvstemming(avstemmingMapper.lagStartmelding())
         while (oppdragSomSkalAvstemmes.isNotEmpty()) {
             val meldinger = avstemmingMapper.lagAvstemmingsmeldinger(oppdragSomSkalAvstemmes)
-            meldinger.forEach {
-                avstemmingSender.sendGrensesnittAvstemming(it)
-            }
+            meldinger.forEach { avstemmingSender.sendGrensesnittAvstemming(it) }
+
             antallMeldinger += meldinger.size
             oppdragSomSkalAvstemmes =
                 oppdragLagerRepository.hentIverksettingerForGrensesnittavstemming(fra, til, fagsystem, antall, page++)

--- a/src/main/kotlin/no/nav/familie/oppdrag/service/GrensesnittavstemmingService.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/service/GrensesnittavstemmingService.kt
@@ -9,6 +9,7 @@ import no.nav.familie.oppdrag.repository.OppdragLagerRepository
 import no.nav.virksomhet.tjenester.avstemming.meldinger.v1.Grunnlagsdata
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import java.time.LocalDateTime
 
@@ -16,6 +17,7 @@ import java.time.LocalDateTime
 class GrensesnittavstemmingService(
     private val avstemmingSender: AvstemmingSender,
     private val oppdragLagerRepository: OppdragLagerRepository,
+    @Value("\${grensesnitt.antall:1000}") private val antall: Int,
 ) {
 
     private var countere: MutableMap<String, Map<String, Counter>> = HashMap()
@@ -28,24 +30,33 @@ class GrensesnittavstemmingService(
 
     fun utførGrensesnittavstemming(request: GrensesnittavstemmingRequest) {
         val (fagsystem: String, fra: LocalDateTime, til: LocalDateTime) = request
-        val oppdragSomSkalAvstemmes = oppdragLagerRepository.hentIverksettingerForGrensesnittavstemming(fra, til, fagsystem)
-        val avstemmingMapper = GrensesnittavstemmingMapper(oppdragSomSkalAvstemmes, fagsystem, fra, til)
-        val meldinger = avstemmingMapper.lagAvstemmingsmeldinger()
-
-        if (meldinger.isEmpty()) {
+        var page = 0
+        var antallMeldinger = 0
+        var oppdragSomSkalAvstemmes =
+            oppdragLagerRepository.hentIverksettingerForGrensesnittavstemming(fra, til, fagsystem, antall, page++)
+        if (oppdragSomSkalAvstemmes.isEmpty()) {
             LOG.info("Ingen oppdrag å gjennomføre grensesnittavstemming for.")
             return
         }
-
-        LOG.info("Utfører grensesnittavstemming for id: ${avstemmingMapper.avstemmingId}, ${meldinger.size} antall meldinger.")
-
-        meldinger.forEach {
-            avstemmingSender.sendGrensesnittAvstemming(it)
+        val avstemmingMapper = GrensesnittavstemmingMapper(fagsystem, fra, til)
+        LOG.info("Utfører grensesnittavstemming for id: ${avstemmingMapper.avstemmingId}")
+        avstemmingSender.sendGrensesnittAvstemming(avstemmingMapper.lagStartmelding())
+        while (oppdragSomSkalAvstemmes.isNotEmpty()) {
+            val meldinger = avstemmingMapper.lagAvstemmingsmeldinger(oppdragSomSkalAvstemmes)
+            meldinger.forEach {
+                avstemmingSender.sendGrensesnittAvstemming(it)
+            }
+            antallMeldinger += meldinger.size
+            oppdragSomSkalAvstemmes =
+                oppdragLagerRepository.hentIverksettingerForGrensesnittavstemming(fra, til, fagsystem, antall, page++)
         }
+        val totalmelding = avstemmingMapper.lagTotalMelding()
+        avstemmingSender.sendGrensesnittAvstemming(totalmelding)
+        avstemmingSender.sendGrensesnittAvstemming(avstemmingMapper.lagSluttmelding())
 
-        LOG.info("Fullført grensesnittavstemming for id: ${avstemmingMapper.avstemmingId}")
+        LOG.info("Fullført grensesnittavstemming for id: ${avstemmingMapper.avstemmingId} antallMeldinger=$antallMeldinger")
 
-        oppdaterMetrikker(fagsystem, meldinger[1].grunnlag)
+        oppdaterMetrikker(fagsystem, totalmelding.grunnlag)
     }
 
     private fun oppdaterMetrikker(fagsystem: String, grunnlag: Grunnlagsdata) {

--- a/src/test/kotlin/no/nav/familie/oppdrag/avstemming/AvstemmingMQSenderTest.kt
+++ b/src/test/kotlin/no/nav/familie/oppdrag/avstemming/AvstemmingMQSenderTest.kt
@@ -7,7 +7,7 @@ import io.mockk.spyk
 import io.mockk.verify
 import no.nav.familie.oppdrag.grensesnittavstemming.GrensesnittavstemmingMapper
 import no.nav.familie.oppdrag.konsistensavstemming.KonsistensavstemmingMapper
-import no.nav.familie.oppdrag.repository.somOppdragLager
+import no.nav.familie.oppdrag.repository.somAvstemming
 import no.nav.familie.oppdrag.util.Containers
 import no.nav.familie.oppdrag.util.TestOppdragMedAvstemmingsdato
 import no.nav.virksomhet.tjenester.avstemming.informasjon.konsistensavstemmingsdata.v1.Konsistensavstemmingsdata
@@ -90,6 +90,6 @@ class AvstemmingMQSenderTest {
     private fun lagTestGrensesnittavstemming(): List<Avstemmingsdata> {
         val utbetalingsoppdrag = TestOppdragMedAvstemmingsdato.lagTestUtbetalingsoppdrag(IDAG, FAGOMRÅDE)
         val mapper = GrensesnittavstemmingMapper(FAGOMRÅDE, IDAG.minusDays(1), IDAG)
-        return mapper.lagAvstemmingsmeldinger(listOf(utbetalingsoppdrag.somOppdragLager))
+        return mapper.lagAvstemmingsmeldinger(listOf(utbetalingsoppdrag.somAvstemming))
     }
 }

--- a/src/test/kotlin/no/nav/familie/oppdrag/avstemming/AvstemmingMQSenderTest.kt
+++ b/src/test/kotlin/no/nav/familie/oppdrag/avstemming/AvstemmingMQSenderTest.kt
@@ -89,7 +89,7 @@ class AvstemmingMQSenderTest {
 
     private fun lagTestGrensesnittavstemming(): List<Avstemmingsdata> {
         val utbetalingsoppdrag = TestOppdragMedAvstemmingsdato.lagTestUtbetalingsoppdrag(IDAG, FAGOMRÅDE)
-        val mapper = GrensesnittavstemmingMapper(listOf(utbetalingsoppdrag.somOppdragLager), FAGOMRÅDE, IDAG.minusDays(1), IDAG)
-        return mapper.lagAvstemmingsmeldinger()
+        val mapper = GrensesnittavstemmingMapper(FAGOMRÅDE, IDAG.minusDays(1), IDAG)
+        return mapper.lagAvstemmingsmeldinger(listOf(utbetalingsoppdrag.somOppdragLager))
     }
 }

--- a/src/test/kotlin/no/nav/familie/oppdrag/grensesnittavstemming/GrensesnittavstemmingMapperTest.kt
+++ b/src/test/kotlin/no/nav/familie/oppdrag/grensesnittavstemming/GrensesnittavstemmingMapperTest.kt
@@ -3,8 +3,8 @@ package no.nav.familie.oppdrag.grensesnittavstemming
 import no.nav.familie.kontrakter.felles.oppdrag.OppdragStatus
 import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsoppdrag
 import no.nav.familie.oppdrag.avstemming.SystemKode
-import no.nav.familie.oppdrag.repository.OppdragLager
-import no.nav.familie.oppdrag.repository.somOppdragLager
+import no.nav.familie.oppdrag.repository.OppdragTilAvstemming
+import no.nav.familie.oppdrag.repository.somAvstemming
 import no.nav.familie.oppdrag.util.TestOppdragMedAvstemmingsdato.lagTestUtbetalingsoppdrag
 import no.nav.familie.oppdrag.util.TestOppdragMedAvstemmingsdato.lagUtbetalingsperiode
 import no.nav.virksomhet.tjenester.avstemming.meldinger.v1.AksjonType
@@ -44,7 +44,7 @@ class GrensesnittavstemmingMapperTest {
         val avstemmingFom = avstemmingstidspunkt.toLocalDate().atStartOfDay()
         val avstemmingTom = avstemmingstidspunkt.toLocalDate().atTime(LocalTime.MAX)
         val utbetalingsoppdrag = lagTestUtbetalingsoppdrag(avstemmingstidspunkt, fagområde)
-        val oppdragLager = utbetalingsoppdrag.somOppdragLager
+        val oppdragLager = utbetalingsoppdrag.somAvstemming
         val mapper = GrensesnittavstemmingMapper(fagområde, avstemmingFom, avstemmingTom)
         val meldinger = mapper.lagAlleMeldinger(listOf(oppdragLager))
         assertEquals(4, meldinger.size)
@@ -78,7 +78,7 @@ class GrensesnittavstemmingMapperTest {
 
         val mapper = GrensesnittavstemmingMapper(fagområde, now.withHour(0), now.withHour(23))
         listOf(oppdrag, oppdrag2, oppdrag3)
-            .forEach { mapper.lagAvstemmingsmeldinger(listOf(it.somOppdragLager.copy(status = OppdragStatus.KVITTERT_OK))) }
+            .forEach { mapper.lagAvstemmingsmeldinger(listOf(it.somAvstemming.copy(status = OppdragStatus.KVITTERT_OK))) }
 
         val totalmelding = mapper.lagTotalMelding()
         assertThat(totalmelding.total.totalAntall).isEqualTo(3)
@@ -99,7 +99,7 @@ class GrensesnittavstemmingMapperTest {
         assertThat(totalmelding.grunnlag.avvistBelop.toInt()).isEqualTo(0)
     }
 
-    fun GrensesnittavstemmingMapper.lagAlleMeldinger(oppdragsliste: List<OppdragLager>) =
+    fun GrensesnittavstemmingMapper.lagAlleMeldinger(oppdragsliste: List<OppdragTilAvstemming>) =
         listOf(lagStartmelding()) + lagAvstemmingsmeldinger(oppdragsliste) + lagTotalMelding() + lagSluttmelding()
 
     @Test
@@ -109,9 +109,9 @@ class GrensesnittavstemmingMapperTest {
         val avstemmingFom = førsteAvstemmingstidspunkt.toLocalDate().atStartOfDay()
         val avstemmingTom = andreAvstemmingstidspunkt.toLocalDate().atTime(LocalTime.MAX)
         val baOppdragLager1 =
-            lagTestUtbetalingsoppdrag(førsteAvstemmingstidspunkt, fagområde).somOppdragLager
+            lagTestUtbetalingsoppdrag(førsteAvstemmingstidspunkt, fagområde).somAvstemming
         val baOppdragLager2 =
-            lagTestUtbetalingsoppdrag(andreAvstemmingstidspunkt, fagområde).somOppdragLager
+            lagTestUtbetalingsoppdrag(andreAvstemmingstidspunkt, fagområde).somAvstemming
         val mapper =
             GrensesnittavstemmingMapper(fagområde, avstemmingFom, avstemmingTom)
         val meldinger = mapper.lagAlleMeldinger(listOf(baOppdragLager1, baOppdragLager2))

--- a/src/test/kotlin/no/nav/familie/oppdrag/grensesnittavstemming/GrensesnittavstemmingMapperTest.kt
+++ b/src/test/kotlin/no/nav/familie/oppdrag/grensesnittavstemming/GrensesnittavstemmingMapperTest.kt
@@ -48,10 +48,11 @@ class GrensesnittavstemmingMapperTest {
         val mapper = GrensesnittavstemmingMapper(fagområde, avstemmingFom, avstemmingTom)
         val meldinger = mapper.lagAlleMeldinger(listOf(oppdragLager))
         assertEquals(4, meldinger.size)
-        assertAksjon(avstemmingFom, avstemmingTom, AksjonType.START, meldinger[0].aksjon)
         val datamelding = meldinger[1]
-        assertAksjon(avstemmingFom, avstemmingTom, AksjonType.DATA, datamelding.aksjon)
         val totalmelding = meldinger[2]
+
+        assertAksjon(avstemmingFom, avstemmingTom, AksjonType.START, meldinger[0].aksjon)
+        assertAksjon(avstemmingFom, avstemmingTom, AksjonType.DATA, datamelding.aksjon)
         assertAksjon(avstemmingFom, avstemmingTom, AksjonType.DATA, totalmelding.aksjon)
         assertAksjon(avstemmingFom, avstemmingTom, AksjonType.AVSL, meldinger.last().aksjon)
 

--- a/src/test/kotlin/no/nav/familie/oppdrag/grensesnittavstemming/GrensesnittavstemmingMapperTest.kt
+++ b/src/test/kotlin/no/nav/familie/oppdrag/grensesnittavstemming/GrensesnittavstemmingMapperTest.kt
@@ -1,9 +1,13 @@
 package no.nav.familie.oppdrag.grensesnittavstemming
 
+import no.nav.familie.kontrakter.felles.oppdrag.OppdragStatus
 import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsoppdrag
 import no.nav.familie.oppdrag.avstemming.SystemKode
+import no.nav.familie.oppdrag.konsistensavstemming.KonsistensavstemmingConstants
+import no.nav.familie.oppdrag.repository.OppdragLager
 import no.nav.familie.oppdrag.repository.somOppdragLager
-import no.nav.familie.oppdrag.util.TestOppdragMedAvstemmingsdato
+import no.nav.familie.oppdrag.util.TestOppdragMedAvstemmingsdato.lagTestUtbetalingsoppdrag
+import no.nav.familie.oppdrag.util.TestOppdragMedAvstemmingsdato.lagUtbetalingsperiode
 import no.nav.virksomhet.tjenester.avstemming.meldinger.v1.AksjonType
 import no.nav.virksomhet.tjenester.avstemming.meldinger.v1.Aksjonsdata
 import no.nav.virksomhet.tjenester.avstemming.meldinger.v1.AvstemmingType
@@ -14,6 +18,8 @@ import no.nav.virksomhet.tjenester.avstemming.meldinger.v1.Grunnlagsdata
 import no.nav.virksomhet.tjenester.avstemming.meldinger.v1.KildeType
 import no.nav.virksomhet.tjenester.avstemming.meldinger.v1.Periodedata
 import no.nav.virksomhet.tjenester.avstemming.meldinger.v1.Totaldata
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import java.math.BigDecimal
 import java.time.LocalDateTime
@@ -22,14 +28,15 @@ import java.time.format.DateTimeFormatter
 import kotlin.test.assertEquals
 
 class GrensesnittavstemmingMapperTest {
+
     val fagområde = "BA"
     val tidspunktFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd-HH.mm.ss.SSSSSS")
 
     @Test
     fun testMappingAvTomListe() {
-        val mapper = GrensesnittavstemmingMapper(emptyList(), fagområde, LocalDateTime.now(), LocalDateTime.now())
-        val meldinger = mapper.lagAvstemmingsmeldinger()
-        assertEquals(0, meldinger.size)
+        val mapper = GrensesnittavstemmingMapper(fagområde, LocalDateTime.now(), LocalDateTime.now())
+        assertThatThrownBy { mapper.lagAvstemmingsmeldinger(emptyList()) }
+            .hasMessageContaining("Kan ikke lage avstemminger med tom liste")
     }
 
     @Test
@@ -37,20 +44,61 @@ class GrensesnittavstemmingMapperTest {
         val avstemmingstidspunkt = LocalDateTime.now().minusDays(1).withHour(13)
         val avstemmingFom = avstemmingstidspunkt.toLocalDate().atStartOfDay()
         val avstemmingTom = avstemmingstidspunkt.toLocalDate().atTime(LocalTime.MAX)
-        val utbetalingsoppdrag = TestOppdragMedAvstemmingsdato.lagTestUtbetalingsoppdrag(avstemmingstidspunkt, fagområde)
+        val utbetalingsoppdrag = lagTestUtbetalingsoppdrag(avstemmingstidspunkt, fagområde)
         val oppdragLager = utbetalingsoppdrag.somOppdragLager
-        val mapper = GrensesnittavstemmingMapper(listOf(oppdragLager), fagområde, avstemmingFom, avstemmingTom)
-        val meldinger = mapper.lagAvstemmingsmeldinger()
-        assertEquals(3, meldinger.size)
-        assertAksjon(avstemmingFom, avstemmingTom, AksjonType.START, meldinger.first().aksjon)
+        val mapper = GrensesnittavstemmingMapper(fagområde, avstemmingFom, avstemmingTom)
+        val meldinger = mapper.lagAlleMeldinger(listOf(oppdragLager))
+        assertEquals(4, meldinger.size)
+        assertAksjon(avstemmingFom, avstemmingTom, AksjonType.START, meldinger[0].aksjon)
         assertAksjon(avstemmingFom, avstemmingTom, AksjonType.DATA, meldinger[1].aksjon)
+        assertAksjon(avstemmingFom, avstemmingTom, AksjonType.DATA, meldinger[2].aksjon)
         assertAksjon(avstemmingFom, avstemmingTom, AksjonType.AVSL, meldinger.last().aksjon)
+        assertThat(meldinger[0].detalj).isEmpty()
+        assertThat(meldinger[1].detalj).hasSize(1)
+        assertThat(meldinger[2].detalj).isEmpty()
+        assertThat(meldinger[3].detalj).isEmpty()
 
-        assertDetaljData(utbetalingsoppdrag, meldinger[1].detalj.first())
-        assertTotalData(utbetalingsoppdrag, meldinger[1].total)
-        assertPeriodeData(utbetalingsoppdrag, meldinger[1].periode)
-        assertGrunnlagsdata(utbetalingsoppdrag, meldinger[1].grunnlag)
+        val totalmelding = meldinger[2]
+        assertDetaljData(utbetalingsoppdrag, totalmelding.detalj.first())
+        assertTotalData(utbetalingsoppdrag, totalmelding.total)
+        assertPeriodeData(utbetalingsoppdrag, totalmelding.periode)
+        assertGrunnlagsdata(utbetalingsoppdrag, totalmelding.grunnlag)
     }
+
+    @Test
+    fun `skal summere flere batcher med oppdrag`() {
+        val now = LocalDateTime.now()
+        val periode = lagUtbetalingsperiode()
+        val utbetalingsperiode = arrayOf(periode)
+        val oppdrag = lagTestUtbetalingsoppdrag(now.minusDays(1), fagområde, utbetalingsperiode = utbetalingsperiode)
+        val oppdrag2 = lagTestUtbetalingsoppdrag(now.plusDays(1), fagområde, utbetalingsperiode = utbetalingsperiode)
+        val oppdrag3 = lagTestUtbetalingsoppdrag(now, fagområde, utbetalingsperiode = arrayOf(periode, periode))
+
+        val mapper = GrensesnittavstemmingMapper(fagområde, now.withHour(0), now.withHour(23))
+        listOf(oppdrag, oppdrag2, oppdrag3)
+            .forEach { mapper.lagAvstemmingsmeldinger(listOf(it.somOppdragLager.copy(status = OppdragStatus.KVITTERT_OK))) }
+
+        val totalmelding = mapper.lagTotalMelding()
+        assertThat(totalmelding.total.totalAntall).isEqualTo(3)
+        assertThat(totalmelding.total.totalBelop.toInt()).isEqualTo(400)
+        assertThat(totalmelding.total.fortegn).isEqualTo(Fortegn.T)
+
+        val avstemtFormatter = DateTimeFormatter.ofPattern("yyyyMMddHH")
+        assertThat(totalmelding.periode.datoAvstemtFom).isEqualTo(now.minusDays(1).format(avstemtFormatter))
+        assertThat(totalmelding.periode.datoAvstemtTom).isEqualTo(now.plusDays(1).format(avstemtFormatter))
+
+        assertThat(totalmelding.grunnlag.godkjentAntall).isEqualTo(3)
+        assertThat(totalmelding.grunnlag.godkjentBelop.toInt()).isEqualTo(400)
+        assertThat(totalmelding.grunnlag.varselAntall).isEqualTo(0)
+        assertThat(totalmelding.grunnlag.varselBelop.toInt()).isEqualTo(0)
+        assertThat(totalmelding.grunnlag.manglerAntall).isEqualTo(0)
+        assertThat(totalmelding.grunnlag.manglerBelop.toInt()).isEqualTo(0)
+        assertThat(totalmelding.grunnlag.avvistAntall).isEqualTo(0)
+        assertThat(totalmelding.grunnlag.avvistBelop.toInt()).isEqualTo(0)
+    }
+
+    fun GrensesnittavstemmingMapper.lagAlleMeldinger(oppdragsliste: List<OppdragLager>) =
+        listOf(lagStartmelding()) + lagAvstemmingsmeldinger(oppdragsliste) + lagTotalMelding() + lagSluttmelding()
 
     @Test
     fun testerAtFomOgTomBlirSattRiktigVedGrensesnittavstemming() {
@@ -59,15 +107,15 @@ class GrensesnittavstemmingMapperTest {
         val avstemmingFom = førsteAvstemmingstidspunkt.toLocalDate().atStartOfDay()
         val avstemmingTom = andreAvstemmingstidspunkt.toLocalDate().atTime(LocalTime.MAX)
         val baOppdragLager1 =
-            TestOppdragMedAvstemmingsdato.lagTestUtbetalingsoppdrag(førsteAvstemmingstidspunkt, fagområde).somOppdragLager
+            lagTestUtbetalingsoppdrag(førsteAvstemmingstidspunkt, fagområde).somOppdragLager
         val baOppdragLager2 =
-            TestOppdragMedAvstemmingsdato.lagTestUtbetalingsoppdrag(andreAvstemmingstidspunkt, fagområde).somOppdragLager
+            lagTestUtbetalingsoppdrag(andreAvstemmingstidspunkt, fagområde).somOppdragLager
         val mapper =
-            GrensesnittavstemmingMapper(listOf(baOppdragLager1, baOppdragLager2), fagområde, avstemmingFom, avstemmingTom)
-        val meldinger = mapper.lagAvstemmingsmeldinger()
-        assertEquals(3, meldinger.size)
-        assertEquals(avstemmingFom.format(tidspunktFormatter), meldinger.first().aksjon.nokkelFom)
-        assertEquals(avstemmingTom.format(tidspunktFormatter), meldinger.first().aksjon.nokkelTom)
+            GrensesnittavstemmingMapper(fagområde, avstemmingFom, avstemmingTom)
+        val meldinger = mapper.lagAlleMeldinger(listOf(baOppdragLager1, baOppdragLager2))
+        assertEquals(4, meldinger.size)
+        assertEquals(avstemmingFom.format(tidspunktFormatter), meldinger[2].aksjon.nokkelFom)
+        assertEquals(avstemmingTom.format(tidspunktFormatter), meldinger[2].aksjon.nokkelTom)
     }
 
     fun assertAksjon(

--- a/src/test/kotlin/no/nav/familie/oppdrag/grensesnittavstemming/GrensesnittavstemmingMapperTest.kt
+++ b/src/test/kotlin/no/nav/familie/oppdrag/grensesnittavstemming/GrensesnittavstemmingMapperTest.kt
@@ -3,7 +3,6 @@ package no.nav.familie.oppdrag.grensesnittavstemming
 import no.nav.familie.kontrakter.felles.oppdrag.OppdragStatus
 import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsoppdrag
 import no.nav.familie.oppdrag.avstemming.SystemKode
-import no.nav.familie.oppdrag.konsistensavstemming.KonsistensavstemmingConstants
 import no.nav.familie.oppdrag.repository.OppdragLager
 import no.nav.familie.oppdrag.repository.somOppdragLager
 import no.nav.familie.oppdrag.util.TestOppdragMedAvstemmingsdato.lagTestUtbetalingsoppdrag
@@ -50,16 +49,19 @@ class GrensesnittavstemmingMapperTest {
         val meldinger = mapper.lagAlleMeldinger(listOf(oppdragLager))
         assertEquals(4, meldinger.size)
         assertAksjon(avstemmingFom, avstemmingTom, AksjonType.START, meldinger[0].aksjon)
-        assertAksjon(avstemmingFom, avstemmingTom, AksjonType.DATA, meldinger[1].aksjon)
-        assertAksjon(avstemmingFom, avstemmingTom, AksjonType.DATA, meldinger[2].aksjon)
+        val datamelding = meldinger[1]
+        assertAksjon(avstemmingFom, avstemmingTom, AksjonType.DATA, datamelding.aksjon)
+        val totalmelding = meldinger[2]
+        assertAksjon(avstemmingFom, avstemmingTom, AksjonType.DATA, totalmelding.aksjon)
         assertAksjon(avstemmingFom, avstemmingTom, AksjonType.AVSL, meldinger.last().aksjon)
+
         assertThat(meldinger[0].detalj).isEmpty()
-        assertThat(meldinger[1].detalj).hasSize(1)
-        assertThat(meldinger[2].detalj).isEmpty()
+        assertThat(datamelding.detalj).hasSize(1)
+        assertThat(totalmelding.detalj).isEmpty()
         assertThat(meldinger[3].detalj).isEmpty()
 
-        val totalmelding = meldinger[2]
-        assertDetaljData(utbetalingsoppdrag, totalmelding.detalj.first())
+        assertDetaljData(utbetalingsoppdrag, datamelding.detalj.single())
+
         assertTotalData(utbetalingsoppdrag, totalmelding.total)
         assertPeriodeData(utbetalingsoppdrag, totalmelding.periode)
         assertGrunnlagsdata(utbetalingsoppdrag, totalmelding.grunnlag)
@@ -69,9 +71,8 @@ class GrensesnittavstemmingMapperTest {
     fun `skal summere flere batcher med oppdrag`() {
         val now = LocalDateTime.now()
         val periode = lagUtbetalingsperiode()
-        val utbetalingsperiode = arrayOf(periode)
-        val oppdrag = lagTestUtbetalingsoppdrag(now.minusDays(1), fagområde, utbetalingsperiode = utbetalingsperiode)
-        val oppdrag2 = lagTestUtbetalingsoppdrag(now.plusDays(1), fagområde, utbetalingsperiode = utbetalingsperiode)
+        val oppdrag = lagTestUtbetalingsoppdrag(now.minusDays(1), fagområde, utbetalingsperiode = arrayOf(periode))
+        val oppdrag2 = lagTestUtbetalingsoppdrag(now.plusDays(1), fagområde, utbetalingsperiode = arrayOf(periode))
         val oppdrag3 = lagTestUtbetalingsoppdrag(now, fagområde, utbetalingsperiode = arrayOf(periode, periode))
 
         val mapper = GrensesnittavstemmingMapper(fagområde, now.withHour(0), now.withHour(23))

--- a/src/test/kotlin/no/nav/familie/oppdrag/repository/OppdragLagerRepositoryJdbcTest.kt
+++ b/src/test/kotlin/no/nav/familie/oppdrag/repository/OppdragLagerRepositoryJdbcTest.kt
@@ -10,11 +10,13 @@ import no.nav.familie.oppdrag.util.TestUtbetalingsoppdrag.utbetalingsoppdragMedT
 import no.trygdeetaten.skjema.oppdrag.Mmel
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.dao.DuplicateKeyException
+import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.ContextConfiguration
 import org.testcontainers.junit.jupiter.Container
@@ -34,9 +36,16 @@ internal class OppdragLagerRepositoryJdbcTest {
 
     @Autowired lateinit var oppdragLagerRepository: OppdragLagerRepository
 
+    @Autowired lateinit var jdbcTemplate: JdbcTemplate
+
     companion object {
 
         @Container var postgreSQLContainer = Containers.postgreSQLContainer
+    }
+
+    @BeforeEach
+    fun setUp() {
+        jdbcTemplate.execute("TRUNCATE TABLE oppdrag_lager")
     }
 
     @Test
@@ -124,7 +133,7 @@ internal class OppdragLagerRepositoryJdbcTest {
         fun hentOppdragForGrensesnittsavstemming(page: Int) =
             oppdragLagerRepository.hentIverksettingerForGrensesnittavstemming(
                 dag.atStartOfDay(),
-                dag.atTime(24, 59),
+                dag.atTime(23, 59),
                 "BA",
                 2,
                 page,
@@ -155,7 +164,7 @@ internal class OppdragLagerRepositoryJdbcTest {
         assertThat(
             oppdragLagerRepository.hentIverksettingerForGrensesnittavstemming(
                 dag.minusDays(1).atStartOfDay(),
-                dag.minusDays(1).atTime(24, 59),
+                dag.minusDays(1).atTime(23, 59),
                 "BA",
                 2,
                 0,

--- a/src/test/kotlin/no/nav/familie/oppdrag/repository/OppdragLagerRepositoryJdbcTest.kt
+++ b/src/test/kotlin/no/nav/familie/oppdrag/repository/OppdragLagerRepositoryJdbcTest.kt
@@ -33,6 +33,7 @@ internal class OppdragLagerRepositoryJdbcTest {
     @Autowired lateinit var oppdragLagerRepository: OppdragLagerRepository
 
     companion object {
+
         @Container var postgreSQLContainer = Containers.postgreSQLContainer
     }
 
@@ -94,7 +95,8 @@ internal class OppdragLagerRepositoryJdbcTest {
 
         val avstemmingsTidspunktetSomSkalKjøres = dag
 
-        val baOppdragLager = TestOppdragMedAvstemmingsdato.lagTestUtbetalingsoppdrag(avstemmingsTidspunktetSomSkalKjøres, "BA").somOppdragLager
+        val baOppdragLager =
+            TestOppdragMedAvstemmingsdato.lagTestUtbetalingsoppdrag(avstemmingsTidspunktetSomSkalKjøres, "BA").somOppdragLager
         val baOppdragLager2 = TestOppdragMedAvstemmingsdato.lagTestUtbetalingsoppdrag(dag.minusDays(1), "BA").somOppdragLager
         val efOppdragLager = TestOppdragMedAvstemmingsdato.lagTestUtbetalingsoppdrag(dag, "EFOG").somOppdragLager
 
@@ -102,7 +104,8 @@ internal class OppdragLagerRepositoryJdbcTest {
         oppdragLagerRepository.opprettOppdrag(baOppdragLager2)
         oppdragLagerRepository.opprettOppdrag(efOppdragLager)
 
-        val oppdrageneTilGrensesnittavstemming = oppdragLagerRepository.hentIverksettingerForGrensesnittavstemming(startenPåDagen, sluttenAvDagen, "BA")
+        val oppdrageneTilGrensesnittavstemming =
+            oppdragLagerRepository.hentIverksettingerForGrensesnittavstemming(startenPåDagen, sluttenAvDagen, "BA", 1, 0)
 
         assertEquals(1, oppdrageneTilGrensesnittavstemming.size)
         assertEquals("BA", oppdrageneTilGrensesnittavstemming.first().fagsystem)
@@ -113,10 +116,37 @@ internal class OppdragLagerRepositoryJdbcTest {
     }
 
     @Test
+    fun `skal kunne hente ut deler av grensesnittsavstemminger`() {
+        val dag = LocalDateTime.now()
+        val startenPåDagen = dag.withHour(0).withMinute(0)
+        val sluttenAvDagen = dag.withHour(23).withMinute(59)
+
+        val avstemmingsTidspunktetSomSkalKjøres = dag
+
+        val baOppdragLager =
+            TestOppdragMedAvstemmingsdato.lagTestUtbetalingsoppdrag(avstemmingsTidspunktetSomSkalKjøres, "BA").somOppdragLager
+        val baOppdragLager2 = TestOppdragMedAvstemmingsdato.lagTestUtbetalingsoppdrag(dag.minusDays(1), "BA").somOppdragLager
+        oppdragLagerRepository.opprettOppdrag(baOppdragLager)
+        oppdragLagerRepository.opprettOppdrag(baOppdragLager2)
+        assertThat(
+            oppdragLagerRepository.hentIverksettingerForGrensesnittavstemming(startenPåDagen, sluttenAvDagen, "BA", 1, 0),
+        ).hasSize(1)
+
+        assertThat(
+            oppdragLagerRepository.hentIverksettingerForGrensesnittavstemming(startenPåDagen, sluttenAvDagen, "BA", 1, 1),
+        ).hasSize(1)
+
+        assertThat(
+            oppdragLagerRepository.hentIverksettingerForGrensesnittavstemming(startenPåDagen, sluttenAvDagen, "BA", 1, 2),
+        ).isEmpty()
+    }
+
+    @Test
     fun skal_hente_ut_oppdrag_for_konsistensavstemming() {
         val forrigeMåned = LocalDateTime.now().minusMonths(1)
         val baOppdragLager = TestOppdragMedAvstemmingsdato.lagTestUtbetalingsoppdrag(forrigeMåned, "BA").somOppdragLager
-        val baOppdragLager2 = TestOppdragMedAvstemmingsdato.lagTestUtbetalingsoppdrag(forrigeMåned.minusDays(1), "BA").somOppdragLager
+        val baOppdragLager2 =
+            TestOppdragMedAvstemmingsdato.lagTestUtbetalingsoppdrag(forrigeMåned.minusDays(1), "BA").somOppdragLager
         oppdragLagerRepository.opprettOppdrag(baOppdragLager)
         oppdragLagerRepository.opprettOppdrag(baOppdragLager2)
 
@@ -194,7 +224,8 @@ internal class OppdragLagerRepositoryJdbcTest {
     fun `hentSisteUtbetalingsoppdragForFagsaker test spørring går fint`() {
         val forrigeMåned = LocalDateTime.now().minusMonths(1)
         val utbetalingsoppdrag1 = TestOppdragMedAvstemmingsdato.lagTestUtbetalingsoppdrag(forrigeMåned, "BA", fagsak = "1")
-        val utbetalingsoppdrag2 = TestOppdragMedAvstemmingsdato.lagTestUtbetalingsoppdrag(forrigeMåned.minusDays(1), "BA", fagsak = "2")
+        val utbetalingsoppdrag2 =
+            TestOppdragMedAvstemmingsdato.lagTestUtbetalingsoppdrag(forrigeMåned.minusDays(1), "BA", fagsak = "2")
 
         val oppdragLager1 = utbetalingsoppdrag1.somOppdragLager
         val oppdragLager2 = utbetalingsoppdrag2.somOppdragLager

--- a/src/test/kotlin/no/nav/familie/oppdrag/repository/OppdragLagerUtil.kt
+++ b/src/test/kotlin/no/nav/familie/oppdrag/repository/OppdragLagerUtil.kt
@@ -1,0 +1,33 @@
+package no.nav.familie.oppdrag.repository
+
+import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsoppdrag
+import no.nav.familie.kontrakter.felles.oppdrag.behandlingsIdForFørsteUtbetalingsperiode
+import no.nav.familie.oppdrag.iverksetting.OppdragMapper
+import java.time.LocalDateTime
+
+fun Utbetalingsoppdrag.somOppdragLagerMedVersjon(versjon: Int): OppdragLager {
+    val tilOppdrag110 = OppdragMapper().tilOppdrag110(this)
+    val oppdrag = OppdragMapper().tilOppdrag(tilOppdrag110)
+    return OppdragLager.lagFraOppdrag(this, oppdrag, versjon)
+}
+
+val Utbetalingsoppdrag.somOppdragLager: OppdragLager
+    get() {
+        val tilOppdrag110 = OppdragMapper().tilOppdrag110(this)
+        val oppdrag = OppdragMapper().tilOppdrag(tilOppdrag110)
+        return OppdragLager.lagFraOppdrag(this, oppdrag)
+    }
+
+val Utbetalingsoppdrag.somAvstemming: OppdragTilAvstemming
+    get() {
+        return OppdragTilAvstemming(
+            personIdent = this.aktoer,
+            fagsystem = this.fagSystem,
+            fagsakId = this.saksnummer,
+            behandlingId = this.behandlingsIdForFørsteUtbetalingsperiode(),
+            avstemmingTidspunkt = this.avstemmingTidspunkt,
+            utbetalingsoppdrag = this,
+            kvitteringsmelding = null,
+            opprettetTidspunkt = LocalDateTime.now(),
+        )
+    }

--- a/src/test/kotlin/no/nav/familie/oppdrag/service/GrensesnittavstemmingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/oppdrag/service/GrensesnittavstemmingServiceTest.kt
@@ -7,7 +7,7 @@ import io.mockk.verify
 import no.nav.familie.kontrakter.felles.oppdrag.GrensesnittavstemmingRequest
 import no.nav.familie.oppdrag.avstemming.AvstemmingSender
 import no.nav.familie.oppdrag.repository.OppdragLagerRepository
-import no.nav.familie.oppdrag.repository.somOppdragLager
+import no.nav.familie.oppdrag.repository.somAvstemming
 import no.nav.familie.oppdrag.util.TestOppdragMedAvstemmingsdato
 import no.nav.virksomhet.tjenester.avstemming.meldinger.v1.AksjonType
 import no.nav.virksomhet.tjenester.avstemming.meldinger.v1.Avstemmingsdata
@@ -41,11 +41,11 @@ class GrensesnittavstemmingServiceTest {
     fun `skal sende en melding på mq per batch`() {
         every { oppdragLagerRepository.hentIverksettingerForGrensesnittavstemming(any(), any(), any(), antall, 0) } returns
             listOf(
-                TestOppdragMedAvstemmingsdato.lagTestUtbetalingsoppdrag(LocalDateTime.now(), fagområde).somOppdragLager,
-                TestOppdragMedAvstemmingsdato.lagTestUtbetalingsoppdrag(LocalDateTime.now(), fagområde).somOppdragLager,
+                TestOppdragMedAvstemmingsdato.lagTestUtbetalingsoppdrag(LocalDateTime.now(), fagområde).somAvstemming,
+                TestOppdragMedAvstemmingsdato.lagTestUtbetalingsoppdrag(LocalDateTime.now(), fagområde).somAvstemming,
             )
         every { oppdragLagerRepository.hentIverksettingerForGrensesnittavstemming(any(), any(), any(), antall, 1) } returns
-            listOf(TestOppdragMedAvstemmingsdato.lagTestUtbetalingsoppdrag(LocalDateTime.now(), fagområde).somOppdragLager)
+            listOf(TestOppdragMedAvstemmingsdato.lagTestUtbetalingsoppdrag(LocalDateTime.now(), fagområde).somAvstemming)
 
         grensesnittavstemmingService.utførGrensesnittavstemming(
             GrensesnittavstemmingRequest(fagområde, LocalDateTime.now(), LocalDateTime.now()),

--- a/src/test/kotlin/no/nav/familie/oppdrag/service/GrensesnittavstemmingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/oppdrag/service/GrensesnittavstemmingServiceTest.kt
@@ -1,0 +1,42 @@
+package no.nav.familie.oppdrag.service
+
+import no.nav.familie.oppdrag.repository.OppdragLagerRepository
+import no.nav.familie.oppdrag.util.Containers
+import no.nav.familie.oppdrag.util.TestConfig
+import no.nav.familie.oppdrag.util.TestUtbetalingsoppdrag
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.DisabledIfEnvironmentVariable
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.jms.annotation.EnableJms
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.ContextConfiguration
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+
+@ActiveProfiles("dev")
+@ContextConfiguration(initializers = [Containers.PostgresSQLInitializer::class, Containers.MQInitializer::class])
+@SpringBootTest(classes = [TestConfig::class], properties = ["spring.cloud.vault.enabled=false"])
+@EnableJms
+@DisabledIfEnvironmentVariable(named = "CIRCLECI", matches = "true")
+@Testcontainers
+class GrensesnittavstemmingServiceTest {
+
+    @Autowired lateinit var grensesnittavstemmingService: GrensesnittavstemmingService
+
+    @Autowired lateinit var oppdragLagerRepository: OppdragLagerRepository
+
+    companion object {
+
+        @Container var postgreSQLContainer = Containers.postgreSQLContainer
+
+        @Container var ibmMQContainer = Containers.ibmMQContainer
+    }
+
+    @Test
+    fun `skal sende grensesnitt`() {
+        val oppdrag1 = TestUtbetalingsoppdrag.utbetalingsoppdragMedTilfeldigAktoer()
+        //  oppdragLagerRepository.opprettOppdrag()
+    }
+}

--- a/src/test/kotlin/no/nav/familie/oppdrag/util/TestOppdragMedAvstemmingsdato.kt
+++ b/src/test/kotlin/no/nav/familie/oppdrag/util/TestOppdragMedAvstemmingsdato.kt
@@ -33,6 +33,7 @@ object TestOppdragMedAvstemmingsdato {
         beløp: Int = 100,
         fom: LocalDate = LocalDate.now().withDayOfMonth(1),
         tom: LocalDate = LocalDate.now().plusYears(6),
+        behandlingId: Long? = null
     ) =
         Utbetalingsperiode(
             erEndringPåEksisterendePeriode = false,
@@ -46,7 +47,7 @@ object TestOppdragMedAvstemmingsdato {
             sats = beløp.toBigDecimal(),
             satsType = Utbetalingsperiode.SatsType.MND,
             utbetalesTil = AKTOER,
-            behandlingId = Random.nextLong(),
+            behandlingId = behandlingId ?: Random.nextLong(),
             utbetalingsgrad = 50,
         )
 }

--- a/src/test/kotlin/no/nav/familie/oppdrag/util/TestOppdragMedAvstemmingsdato.kt
+++ b/src/test/kotlin/no/nav/familie/oppdrag/util/TestOppdragMedAvstemmingsdato.kt
@@ -33,7 +33,7 @@ object TestOppdragMedAvstemmingsdato {
         beløp: Int = 100,
         fom: LocalDate = LocalDate.now().withDayOfMonth(1),
         tom: LocalDate = LocalDate.now().plusYears(6),
-        behandlingId: Long? = null
+        behandlingId: Long? = null,
     ) =
         Utbetalingsperiode(
             erEndringPåEksisterendePeriode = false,

--- a/src/test/resources/application-dev.yaml
+++ b/src/test/resources/application-dev.yaml
@@ -11,6 +11,9 @@ oppdrag.mq:
   password: passw0rd
   enabled: true
 
+grensesnitt:
+  antall: 2
+
 no.nav.security.jwt:
   issuer.azuread:
     discoveryurl: ${AZURE_APP_WELL_KNOWN_URL}


### PR DESCRIPTION
For å unngå OOM når man skal grensesnittsavstemme så hentes 7000 oppdrag opp fra basen.
Disse batches i tillegg opp i ulike meldinger, 70 per "datamelding" (det gjøres fra før)

Endrer til å sende totalmeldingen som en egen melding på slutten, det samme gjøres i konsistensavstemming.

Henter ikke opp "utgående oppdrag" fra basen ved grensesnittsavstemming.

![image](https://github.com/navikt/familie-oppdrag/assets/937168/9ba5893e-dd84-4da5-b1a6-8f284f8e379f)
