### PR TITLE
Kvitteringsmelding trenger ikke å hente opp hele OppdragLager

### DIFF
--- a/src/main/kotlin/no/nav/familie/oppdrag/repository/Kvitteringsinformasjon.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/repository/Kvitteringsinformasjon.kt
@@ -1,0 +1,44 @@
+package no.nav.familie.oppdrag.repository
+
+import com.fasterxml.jackson.module.kotlin.readValue
+import no.nav.familie.kontrakter.felles.objectMapper
+import no.nav.familie.kontrakter.felles.oppdrag.OppdragId
+import no.nav.familie.kontrakter.felles.oppdrag.OppdragStatus
+import no.trygdeetaten.skjema.oppdrag.Mmel
+import org.springframework.jdbc.core.RowMapper
+import java.sql.ResultSet
+import java.time.LocalDateTime
+
+data class Kvitteringsinformasjon(
+    val fagsystem: String,
+    val personIdent: String,
+    val fagsakId: String,
+    val behandlingId: String,
+    var status: OppdragStatus = OppdragStatus.LAGT_PÅ_KØ,
+    val avstemmingTidspunkt: LocalDateTime,
+    val opprettetTidspunkt: LocalDateTime,
+    val kvitteringsmelding: Mmel?,
+    val versjon: Int,
+)
+
+val Kvitteringsinformasjon.id: OppdragId
+    get() {
+        return OppdragId(this.fagsystem, this.personIdent, this.behandlingId)
+    }
+
+object KvitteringsinformasjonRowMapper : RowMapper<Kvitteringsinformasjon> {
+
+    override fun mapRow(resultSet: ResultSet, rowNumbers: Int): Kvitteringsinformasjon {
+        return Kvitteringsinformasjon(
+            fagsystem = resultSet.getString("fagsystem"),
+            personIdent = resultSet.getString("person_ident"),
+            fagsakId = resultSet.getString("fagsak_id"),
+            behandlingId = resultSet.getString("behandling_id"),
+            status = OppdragStatus.valueOf(resultSet.getString("status")),
+            avstemmingTidspunkt = resultSet.getTimestamp("avstemming_tidspunkt").toLocalDateTime(),
+            opprettetTidspunkt = resultSet.getTimestamp("opprettet_tidspunkt").toLocalDateTime(),
+            kvitteringsmelding = resultSet.getString("kvitteringsmelding")?.let { objectMapper.readValue(it) },
+            versjon = resultSet.getInt("versjon"),
+        )
+    }
+}

--- a/src/main/kotlin/no/nav/familie/oppdrag/repository/OppdragLagerRepository.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/repository/OppdragLagerRepository.kt
@@ -10,10 +10,10 @@ interface OppdragLagerRepository {
 
     fun hentOppdrag(oppdragId: OppdragId, versjon: Int = 0): OppdragLager
     fun hentUtbetalingsoppdrag(oppdragId: OppdragId, versjon: Int = 0): Utbetalingsoppdrag
-    fun hentAlleVersjonerAvOppdrag(oppdragId: OppdragId): List<OppdragLager>
     fun opprettOppdrag(oppdragLager: OppdragLager, versjon: Int = 0)
     fun oppdaterStatus(oppdragId: OppdragId, oppdragStatus: OppdragStatus, versjon: Int = 0)
-    fun oppdaterKvitteringsmelding(oppdragId: OppdragId, kvittering: Mmel, versjon: Int = 0)
+    fun hentKvitteringsinformasjon(oppdragId: OppdragId): List<Kvitteringsinformasjon>
+    fun oppdaterKvitteringsmelding(oppdragId: OppdragId, oppdragStatus: OppdragStatus, kvittering: Mmel?, versjon: Int = 0)
     fun hentIverksettingerForGrensesnittavstemming(
         fomTidspunkt: LocalDateTime,
         tomTidspunkt: LocalDateTime,

--- a/src/test/kotlin/no/nav/familie/oppdrag/repository/OppdragLagerRepositoryJdbcTest.kt
+++ b/src/test/kotlin/no/nav/familie/oppdrag/repository/OppdragLagerRepositoryJdbcTest.kt
@@ -69,13 +69,31 @@ internal class OppdragLagerRepositoryJdbcTest {
             .copy(status = OppdragStatus.LAGT_PÅ_KØ)
 
         oppdragLagerRepository.opprettOppdrag(oppdragLager)
-        val hentetOppdrag = oppdragLagerRepository.hentOppdrag(oppdragLager.id)
+        val hentetOppdrag = oppdragLagerRepository.hentKvitteringsinformasjon(oppdragLager.id).single()
         val kvitteringsmelding = kvitteringsmelding()
 
-        oppdragLagerRepository.oppdaterKvitteringsmelding(hentetOppdrag.id, kvitteringsmelding)
+        oppdragLagerRepository.oppdaterKvitteringsmelding(hentetOppdrag.id, OppdragStatus.KVITTERT_OK, kvitteringsmelding, 0)
 
         val hentetOppdatertOppdrag = oppdragLagerRepository.hentOppdrag(oppdragLager.id)
-        assertThat(kvitteringsmelding).isEqualToComparingFieldByField(hentetOppdatertOppdrag.kvitteringsmelding)
+        assertThat(hentetOppdatertOppdrag.status).isEqualTo(OppdragStatus.KVITTERT_OK)
+        assertThat(hentetOppdatertOppdrag.kvitteringsmelding)
+            .usingRecursiveComparison()
+            .isEqualTo(kvitteringsmelding)
+    }
+
+    @Test
+    fun `skal kun sette kvitteringsmeldingen til null`() {
+        val oppdragLager = utbetalingsoppdragMedTilfeldigAktoer().somOppdragLager
+            .copy(status = OppdragStatus.LAGT_PÅ_KØ, kvitteringsmelding = kvitteringsmelding())
+
+        oppdragLagerRepository.opprettOppdrag(oppdragLager)
+        val hentetOppdrag = oppdragLagerRepository.hentKvitteringsinformasjon(oppdragLager.id).single()
+
+        oppdragLagerRepository.oppdaterKvitteringsmelding(hentetOppdrag.id, OppdragStatus.KVITTERT_UKJENT, null, 0)
+
+        val hentetOppdatertOppdrag = oppdragLagerRepository.hentOppdrag(oppdragLager.id)
+        assertThat(hentetOppdatertOppdrag.status).isEqualTo(OppdragStatus.KVITTERT_UKJENT)
+        assertThat(hentetOppdatertOppdrag.kvitteringsmelding).isNull()
     }
 
     private fun kvitteringsmelding(): Mmel {

--- a/src/test/kotlin/no/nav/familie/oppdrag/repository/OppdragLagerUtil.kt
+++ b/src/test/kotlin/no/nav/familie/oppdrag/repository/OppdragLagerUtil.kt
@@ -1,0 +1,21 @@
+package no.nav.familie.oppdrag.repository
+
+import no.nav.familie.kontrakter.felles.oppdrag.OppdragStatus
+import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsoppdrag
+import no.nav.familie.kontrakter.felles.oppdrag.behandlingsIdForFørsteUtbetalingsperiode
+import java.time.LocalDateTime
+
+val Utbetalingsoppdrag.somKvitteringsinformasjon: Kvitteringsinformasjon
+    get() {
+        return Kvitteringsinformasjon(
+            fagsystem = this.fagSystem,
+            personIdent = this.aktoer,
+            fagsakId = this.saksnummer,
+            behandlingId = this.behandlingsIdForFørsteUtbetalingsperiode(),
+            avstemmingTidspunkt = this.avstemmingTidspunkt,
+            kvitteringsmelding = null,
+            opprettetTidspunkt = LocalDateTime.now(),
+            status = OppdragStatus.LAGT_PÅ_KØ,
+            versjon = 0,
+        )
+    }


### PR DESCRIPTION
* Gjør kun en oppdatering mot databasen i stedet for 2 då kvitteringsmeldingen alltid finnes for kvittert_ok, som er det som skjer i nesten alle tilfeller