### PR TITLE
Vi oppretter et endepunkt som tillater oss å opprette manuelle kvittering på oppdrag

### DIFF
--- a/src/main/kotlin/no/nav/familie/oppdrag/rest/OppdragController.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/rest/OppdragController.kt
@@ -11,6 +11,7 @@ import no.nav.familie.oppdrag.common.RessursUtils.notFound
 import no.nav.familie.oppdrag.common.RessursUtils.ok
 import no.nav.familie.oppdrag.iverksetting.OppdragMapper
 import no.nav.familie.oppdrag.service.OppdragAlleredeSendtException
+import no.nav.familie.oppdrag.service.OppdragHarAlleredeKvitteringException
 import no.nav.familie.oppdrag.service.OppdragService
 import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.beans.factory.annotation.Autowired
@@ -76,7 +77,7 @@ class OppdragController(
     }
 
     @PostMapping("resend")
-    fun resentOppdrag(
+    fun resendOppdrag(
         @Valid @RequestBody
         oppdragId: OppdragId,
     ) {
@@ -92,6 +93,26 @@ class OppdragController(
             .fold(
                 onFailure = {
                     notFound("Fant ikke oppdrag med id $oppdragId")
+                },
+                onSuccess = {
+                    ok(it.status, it.kvitteringsmelding?.beskrMelding ?: "Savner kvitteringsmelding")
+                },
+            )
+    }
+
+    @PostMapping(consumes = [MediaType.APPLICATION_JSON_VALUE], path = ["/oppdrag/manuell-kvittering"])
+    fun opprettManuellKvitteringPåOppdrag(
+        @Valid @RequestBody
+        oppdragId: OppdragId,
+    ): ResponseEntity<Ressurs<OppdragStatus>> {
+        return Result.runCatching { oppdragService.opprettManuellKvitteringPåOppdrag(oppdragId) }
+            .fold(
+                onFailure = {
+                    if (it is OppdragHarAlleredeKvitteringException) {
+                        conflict("Oppdrag med id $oppdragId er allerede kvittert ut.")
+                    } else {
+                        illegalState("Klarte ikke opprette manuell kvittering for oppdrag med id $oppdragId", it)
+                    }
                 },
                 onSuccess = {
                     ok(it.status, it.kvitteringsmelding?.beskrMelding ?: "Savner kvitteringsmelding")

--- a/src/main/kotlin/no/nav/familie/oppdrag/service/OppdragService.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/service/OppdragService.kt
@@ -9,4 +9,5 @@ interface OppdragService {
     fun opprettOppdrag(utbetalingsoppdrag: Utbetalingsoppdrag, oppdrag: Oppdrag, versjon: Int)
     fun hentStatusForOppdrag(oppdragId: OppdragId): OppdragLager
     fun resendOppdrag(oppdragId: OppdragId)
+    fun opprettManuellKvitteringPåOppdrag(oppdragId: OppdragId): OppdragLager
 }

--- a/src/main/kotlin/no/nav/familie/oppdrag/service/OppdragServiceE2E.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/service/OppdragServiceE2E.kt
@@ -36,6 +36,10 @@ class OppdragServiceE2E(
         throw NotImplementedError("Ikke implementert")
     }
 
+    override fun opprettManuellKvitteringPåOppdrag(oppdragId: OppdragId): OppdragLager {
+        throw NotImplementedError("Ikke implementert")
+    }
+
     companion object {
 
         val LOG = LoggerFactory.getLogger(OppdragServiceE2E::class.java)

--- a/src/main/kotlin/no/nav/familie/oppdrag/service/OppdragServiceImpl.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/service/OppdragServiceImpl.kt
@@ -8,6 +8,7 @@ import no.nav.familie.oppdrag.iverksetting.Jaxb
 import no.nav.familie.oppdrag.iverksetting.OppdragSender
 import no.nav.familie.oppdrag.repository.OppdragLager
 import no.nav.familie.oppdrag.repository.OppdragLagerRepository
+import no.trygdeetaten.skjema.oppdrag.Mmel
 import no.trygdeetaten.skjema.oppdrag.Oppdrag
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
@@ -52,6 +53,25 @@ class OppdragServiceImpl(
         oppdragSender.sendOppdrag(oppdragXml)
     }
 
+    override fun opprettManuellKvitteringPåOppdrag(oppdragId: OppdragId): OppdragLager {
+        val oppdrag = oppdragLagerRepository.hentOppdrag(oppdragId)
+
+        if (oppdrag.status != OppdragStatus.LAGT_PÅ_KØ) {
+            throw OppdragHarAlleredeKvitteringException("Oppdrag med id $oppdragId er allerede kvittert ut.")
+        }
+
+        val manuellKvittering = Mmel().apply { beskrMelding = "Manuelt kvittert ut" }
+
+        oppdragLagerRepository.oppdaterKvitteringsmelding(
+            oppdragId = oppdragId,
+            oppdragStatus = OppdragStatus.KVITTERT_OK,
+            kvittering = manuellKvittering,
+            versjon = oppdrag.versjon + 1,
+        )
+
+        return oppdrag
+    }
+
     companion object {
 
         val LOG = LoggerFactory.getLogger(OppdragServiceImpl::class.java)
@@ -59,3 +79,4 @@ class OppdragServiceImpl(
 }
 
 class OppdragAlleredeSendtException() : RuntimeException()
+class OppdragHarAlleredeKvitteringException(melding: String) : RuntimeException(melding)

--- a/src/test/kotlin/no/nav/familie/oppdrag/rest/OppdragControllerIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/familie/oppdrag/rest/OppdragControllerIntegrationTest.kt
@@ -83,7 +83,7 @@ internal class OppdragControllerIntegrationTest {
         oppdragController.sendOppdrag(utbetalingsoppdrag)
         oppdragLagerRepository.oppdaterStatus(utbetalingsoppdrag.oppdragId, OppdragStatus.KVITTERT_FUNKSJONELL_FEIL)
 
-        oppdragController.resentOppdrag(utbetalingsoppdrag.oppdragId)
+        oppdragController.resendOppdrag(utbetalingsoppdrag.oppdragId)
         assertOppdragStatus(utbetalingsoppdrag.oppdragId, OppdragStatus.KVITTERT_OK)
     }
 

--- a/src/test/kotlin/no/nav/familie/oppdrag/rest/OppdragControllerTest.kt
+++ b/src/test/kotlin/no/nav/familie/oppdrag/rest/OppdragControllerTest.kt
@@ -4,8 +4,10 @@ import io.mockk.Runs
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
+import io.mockk.runs
 import io.mockk.verify
 import no.nav.familie.kontrakter.felles.Ressurs
+import no.nav.familie.kontrakter.felles.oppdrag.OppdragId
 import no.nav.familie.kontrakter.felles.oppdrag.OppdragStatus
 import no.nav.familie.kontrakter.felles.oppdrag.Opphør
 import no.nav.familie.kontrakter.felles.oppdrag.Utbetalingsoppdrag
@@ -15,6 +17,7 @@ import no.nav.familie.oppdrag.iverksetting.OppdragSender
 import no.nav.familie.oppdrag.repository.OppdragLager
 import no.nav.familie.oppdrag.repository.OppdragLagerRepository
 import no.nav.familie.oppdrag.service.OppdragServiceImpl
+import no.trygdeetaten.skjema.oppdrag.Mmel
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpStatus
 import java.math.BigDecimal
@@ -79,6 +82,45 @@ internal class OppdragControllerTest {
         assertEquals(Ressurs.Status.FEILET, response.body?.status)
 
         verify(exactly = 1) { oppdragLagerRepository.opprettOppdrag(any()) }
+    }
+
+    @Test
+    fun `Skal kaste 409 feil om oppdrag allerede er kvittert ut`() {
+        val (oppdragLagerRepository, oppdragController) = mockkOppdragController(false)
+        val oppdragId = OppdragId(fagsystem = "BA", personIdent = "test", behandlingsId = "0")
+        val mocketOppdragLager = mockk<OppdragLager>()
+
+        every { mocketOppdragLager.status } returns OppdragStatus.KVITTERT_OK
+        every { oppdragLagerRepository.hentOppdrag(oppdragId) } returns mocketOppdragLager
+
+        val response = oppdragController.opprettManuellKvitteringPåOppdrag(oppdragId)
+
+        assertEquals(HttpStatus.CONFLICT, response.statusCode)
+        assertEquals(Ressurs.Status.FEILET, response.body?.status)
+
+        verify(exactly = 1) { oppdragLagerRepository.hentOppdrag(any()) }
+    }
+
+    @Test
+    fun `Skal returnere 200 OK om oppdrag ble manuelt kvittert ut`() {
+        val (oppdragLagerRepository, oppdragController) = mockkOppdragController(false)
+        val oppdragId = OppdragId(fagsystem = "BA", personIdent = "test", behandlingsId = "0")
+        val mocketOppdragLager = mockk<OppdragLager>()
+
+        every { mocketOppdragLager.status } returns OppdragStatus.LAGT_PÅ_KØ
+        every { mocketOppdragLager.versjon } returns 0
+        every { mocketOppdragLager.kvitteringsmelding } returns Mmel().apply { beskrMelding = "Manuelt kvittert ut" }
+
+        every { oppdragLagerRepository.hentOppdrag(oppdragId) } returns mocketOppdragLager
+        every { oppdragLagerRepository.oppdaterKvitteringsmelding(oppdragId, OppdragStatus.KVITTERT_OK, any(), 1) } just runs
+
+        val response = oppdragController.opprettManuellKvitteringPåOppdrag(oppdragId)
+
+        assertEquals(HttpStatus.OK, response.statusCode)
+        assertEquals("Manuelt kvittert ut", response.body?.melding)
+
+        verify(exactly = 1) { oppdragLagerRepository.hentOppdrag(any()) }
+        verify(exactly = 1) { oppdragLagerRepository.oppdaterKvitteringsmelding(oppdragId, OppdragStatus.KVITTERT_OK, any(), 1) }
     }
 
     private fun mockkOppdragController(alleredeOpprettet: Boolean = false): Pair<OppdragLagerRepository, OppdragController> {


### PR DESCRIPTION
Favrokort: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-16760

Vi ønsker å ha mulighet til å manuelt opprette kvittering på oppdrag dersom det er slik at oppdraget er vellykket og har gått gjennom hos Økonomi, men vi ikke har mottatt kvittering på dette (de forsvinner av og til).

Det er derfor opprettet et endepunkt i familie-oppdrag som kalles fra familie-ba-sak som gjør akkurat dette.

PR i ba-sak: https://github.com/navikt/familie-ba-sak/pull/4148