### PR TITLE
Ikke rekjør grensesnittavstemming ved samme avstemmingId dersom forrige gikk OK

### DIFF
--- a/app-preprod.yaml
+++ b/app-preprod.yaml
@@ -69,9 +69,7 @@ spec:
       external:
         - host: b27apvl220.preprod.local
           ports:
-            - name: mq
-              port: 1413
-              protocol: TCP
+            - port: 1413
   env:
     - name: SPRING_PROFILES_ACTIVE
       value: preprod

--- a/app-prod.yaml
+++ b/app-prod.yaml
@@ -64,9 +64,7 @@ spec:
       external:
         - host: mpls02.adeo.no
           ports:
-            - name: mq
-              port: 1414
-              protocol: TCP
+            - port: 1414
   env:
     - name: SPRING_PROFILES_ACTIVE
       value: prod

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <kotlin.version>1.9.0</kotlin.version>
         <main-class>no.nav.familie.oppdrag.LauncherKt</main-class>
         <felles.version>2.20230508082643_6b28bd8</felles.version>
-        <kontrakter.version>3.0_20230808083340_ced4750</kontrakter.version>
+        <kontrakter.version>3.0_20240122110213_5591a29</kontrakter.version>
         <token-validation-spring.version>3.1.2</token-validation-spring.version>
 
         <!--

--- a/src/main/kotlin/no/nav/familie/oppdrag/repository/TidligereKjørtGrensesnittavstemming.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/repository/TidligereKjørtGrensesnittavstemming.kt
@@ -5,6 +5,6 @@ import org.springframework.data.annotation.Id
 import org.springframework.data.relational.core.mapping.Table
 
 @Table("tidligere_kjoerte_grensesnittavstemminger")
-class TidligereKjørteGrensesnittavstemminger(
+class TidligereKjørtGrensesnittavstemming(
     @Id val id: UUID
 )

--- a/src/main/kotlin/no/nav/familie/oppdrag/repository/TidligereKjørteGrensesnittavstemminger.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/repository/TidligereKjørteGrensesnittavstemminger.kt
@@ -1,0 +1,10 @@
+package no.nav.familie.oppdrag.repository
+
+import java.util.UUID
+import org.springframework.data.annotation.Id
+import org.springframework.data.relational.core.mapping.Table
+
+@Table("tidligere_kjoerte_grensesnittavstemminger")
+class TidligereKjørteGrensesnittavstemminger(
+    @Id val id: UUID
+)

--- a/src/main/kotlin/no/nav/familie/oppdrag/repository/TidligereKjørteGrensesnittavstemmingerRepository.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/repository/TidligereKjørteGrensesnittavstemmingerRepository.kt
@@ -6,8 +6,8 @@ import org.springframework.data.repository.CrudRepository
 import org.springframework.stereotype.Repository
 
 @Repository
-interface TidligereKjørteGrensesnittavstemmingerRepository : InsertUpdateRepository<TidligereKjørteGrensesnittavstemminger>,
-    CrudRepository<TidligereKjørteGrensesnittavstemminger, UUID> {
+interface TidligereKjørteGrensesnittavstemmingerRepository : InsertUpdateRepository<TidligereKjørtGrensesnittavstemming>,
+    CrudRepository<TidligereKjørtGrensesnittavstemming, UUID> {
 
-    override fun findById(id: UUID): Optional<TidligereKjørteGrensesnittavstemminger>
+    override fun findById(id: UUID): Optional<TidligereKjørtGrensesnittavstemming>
 }

--- a/src/main/kotlin/no/nav/familie/oppdrag/repository/TidligereKjørteGrensesnittavstemmingerRepository.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/repository/TidligereKjørteGrensesnittavstemmingerRepository.kt
@@ -7,7 +7,4 @@ import org.springframework.stereotype.Repository
 
 @Repository
 interface TidligereKjørteGrensesnittavstemmingerRepository : InsertUpdateRepository<TidligereKjørtGrensesnittavstemming>,
-    CrudRepository<TidligereKjørtGrensesnittavstemming, UUID> {
-
-    override fun findById(id: UUID): Optional<TidligereKjørtGrensesnittavstemming>
-}
+    CrudRepository<TidligereKjørtGrensesnittavstemming, UUID>

--- a/src/main/kotlin/no/nav/familie/oppdrag/repository/TidligereKjørteGrensesnittavstemmingerRepository.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/repository/TidligereKjørteGrensesnittavstemmingerRepository.kt
@@ -1,0 +1,13 @@
+package no.nav.familie.oppdrag.repository
+
+import java.util.Optional
+import java.util.UUID
+import org.springframework.data.repository.CrudRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface TidligereKjørteGrensesnittavstemmingerRepository : InsertUpdateRepository<TidligereKjørteGrensesnittavstemminger>,
+    CrudRepository<TidligereKjørteGrensesnittavstemminger, UUID> {
+
+    override fun findById(id: UUID): Optional<TidligereKjørteGrensesnittavstemminger>
+}

--- a/src/main/kotlin/no/nav/familie/oppdrag/service/GrensesnittavstemmingService.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/service/GrensesnittavstemmingService.kt
@@ -13,7 +13,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import java.time.LocalDateTime
-import no.nav.familie.oppdrag.repository.TidligereKjørteGrensesnittavstemminger
+import no.nav.familie.oppdrag.repository.TidligereKjørtGrensesnittavstemming
 import no.nav.familie.oppdrag.repository.TidligereKjørteGrensesnittavstemmingerRepository
 import kotlin.jvm.optionals.getOrNull
 
@@ -68,7 +68,7 @@ class GrensesnittavstemmingService(
         avstemmingSender.sendGrensesnittAvstemming(avstemmingMapper.lagSluttmelding())
 
         if (avstemmingId != null) {
-            tidligereKjørteGrensesnittavstemmingerRepository.insert(TidligereKjørteGrensesnittavstemminger(avstemmingId))
+            tidligereKjørteGrensesnittavstemmingerRepository.insert(TidligereKjørtGrensesnittavstemming(avstemmingId))
         }
 
         LOG.info(

--- a/src/main/kotlin/no/nav/familie/oppdrag/service/GrensesnittavstemmingService.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/service/GrensesnittavstemmingService.kt
@@ -13,11 +13,15 @@ import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import java.time.LocalDateTime
+import no.nav.familie.oppdrag.repository.TidligereKjørteGrensesnittavstemminger
+import no.nav.familie.oppdrag.repository.TidligereKjørteGrensesnittavstemmingerRepository
+import kotlin.jvm.optionals.getOrNull
 
 @Service
 class GrensesnittavstemmingService(
     private val avstemmingSender: AvstemmingSender,
     private val oppdragLagerRepository: OppdragLagerRepository,
+    private val tidligereKjørteGrensesnittavstemmingerRepository: TidligereKjørteGrensesnittavstemmingerRepository,
     @Value("\${grensesnitt.antall:7000}") private val antall: Int,
 ) {
 
@@ -31,7 +35,15 @@ class GrensesnittavstemmingService(
     }
 
     fun utførGrensesnittavstemming(request: GrensesnittavstemmingRequest) {
-        val (fagsystem: String, fra: LocalDateTime, til: LocalDateTime) = request
+        val (fagsystem: String, fra: LocalDateTime, til: LocalDateTime, avstemmingId) = request
+
+        val erGrensesnittavstemmingKjørtPåSammeAvstemmingId =
+            avstemmingId?.let { tidligereKjørteGrensesnittavstemmingerRepository.findById(it).getOrNull() } != null
+        if (erGrensesnittavstemmingKjørtPåSammeAvstemmingId) {
+            LOG.info("Grensesnittavstemming er allerede fullført for $avstemmingId og vil ikke bli kjørt på nytt")
+            return
+        }
+
         var page = 0
         var antallOppdragSomSkalAvstemmes = 0
         var oppdragSomSkalAvstemmes =
@@ -54,6 +66,10 @@ class GrensesnittavstemmingService(
         val totalmelding = avstemmingMapper.lagTotalMelding()
         avstemmingSender.sendGrensesnittAvstemming(totalmelding)
         avstemmingSender.sendGrensesnittAvstemming(avstemmingMapper.lagSluttmelding())
+
+        if (avstemmingId != null) {
+            tidligereKjørteGrensesnittavstemmingerRepository.insert(TidligereKjørteGrensesnittavstemminger(avstemmingId))
+        }
 
         LOG.info(
             "Fullført grensesnittavstemming for id: ${avstemmingMapper.avstemmingId}" +

--- a/src/main/resources/db/migration/V013__opprett_tidligere_kjoerte_grensesnittavstemminger.sql
+++ b/src/main/resources/db/migration/V013__opprett_tidligere_kjoerte_grensesnittavstemminger.sql
@@ -1,4 +1,4 @@
 CREATE TABLE tidligere_kjoerte_grensesnittavstemminger
 (
-    id UUID PRIMARY KEY,
+  id UUID PRIMARY KEY NOT NULL
 );

--- a/src/main/resources/db/migration/V013__opprett_tidligere_kjoerte_grensesnittavstemminger.sql
+++ b/src/main/resources/db/migration/V013__opprett_tidligere_kjoerte_grensesnittavstemminger.sql
@@ -1,0 +1,4 @@
+CREATE TABLE tidligere_kjoerte_grensesnittavstemminger
+(
+    id UUID PRIMARY KEY,
+);

--- a/src/test/kotlin/no/nav/familie/oppdrag/grensesnittavstemming/GrensesnittavstemmingIdTest.kt
+++ b/src/test/kotlin/no/nav/familie/oppdrag/grensesnittavstemming/GrensesnittavstemmingIdTest.kt
@@ -166,7 +166,7 @@ class GrensesnittavstemmingIdTest(
     }
 
     @Test
-    fun `Skal være mulig å kjøre grensesnittavstemming flere ganger når om man bruker forskjellig avstemmingId`() {
+    fun `Skal være mulig å kjøre grensesnittavstemming flere ganger om man bruker forskjellig avstemmingId`() {
         val logger: Logger = LoggerFactory.getLogger(GrensesnittavstemmingService::class.java) as Logger
         logger.addAppender(listAppender)
 

--- a/src/test/kotlin/no/nav/familie/oppdrag/grensesnittavstemming/GrensesnittavstemmingIdTest.kt
+++ b/src/test/kotlin/no/nav/familie/oppdrag/grensesnittavstemming/GrensesnittavstemmingIdTest.kt
@@ -1,0 +1,207 @@
+package no.nav.familie.oppdrag.grensesnittavstemming
+
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
+import io.mockk.every
+import io.mockk.mockk
+import java.time.LocalDateTime
+import java.util.*
+import no.nav.familie.kontrakter.felles.oppdrag.GrensesnittavstemmingRequest
+import no.nav.familie.oppdrag.avstemming.AvstemmingSender
+import no.nav.familie.oppdrag.iverksetting.OppdragMapper
+import no.nav.familie.oppdrag.repository.OppdragLager
+import no.nav.familie.oppdrag.repository.OppdragLagerRepository
+import no.nav.familie.oppdrag.repository.TidligereKjørtGrensesnittavstemming
+import no.nav.familie.oppdrag.repository.TidligereKjørteGrensesnittavstemmingerRepository
+import no.nav.familie.oppdrag.service.GrensesnittavstemmingService
+import no.nav.familie.oppdrag.util.Containers
+import no.nav.familie.oppdrag.util.TestConfig
+import no.nav.familie.oppdrag.util.TestOppdragMedAvstemmingsdato
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.ContextConfiguration
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+
+
+@ActiveProfiles("dev")
+@ContextConfiguration(initializers = arrayOf(Containers.PostgresSQLInitializer::class))
+@SpringBootTest(classes = [TestConfig::class], properties = ["spring.cloud.vault.enabled=false"])
+@Testcontainers
+class GrensesnittavstemmingIdTest(
+    @Autowired
+    val tidligereKjørteGrensesnittavstemmingerRepository: TidligereKjørteGrensesnittavstemmingerRepository,
+    @Autowired
+    val jdbcTemplate: JdbcTemplate,
+    @Autowired
+    val oppdragLagerRepository: OppdragLagerRepository,
+    @Autowired val oppdragMapper: OppdragMapper,
+) {
+
+    val avstemmingSender: AvstemmingSender = mockk()
+
+
+    val grensesnittavstemmingService = GrensesnittavstemmingService(
+        avstemmingSender = avstemmingSender,
+        oppdragLagerRepository = oppdragLagerRepository,
+        tidligereKjørteGrensesnittavstemmingerRepository = tidligereKjørteGrensesnittavstemmingerRepository,
+        antall = 2
+    )
+
+    companion object {
+        protected fun initLoggingEventListAppender(): ListAppender<ILoggingEvent> {
+            val listAppender = ListAppender<ILoggingEvent>()
+            listAppender.start()
+            return listAppender
+        }
+
+
+        @Container
+        var postgreSQLContainer = Containers.postgreSQLContainer
+    }
+
+    private val listAppender = initLoggingEventListAppender()
+
+    @BeforeEach
+    fun setUp() {
+        jdbcTemplate.execute("TRUNCATE TABLE tidligere_kjoerte_grensesnittavstemminger")
+    }
+
+    @Test
+    fun `Skal kunne lagre avstemming Id`() {
+        val uuid = UUID.randomUUID()
+        tidligereKjørteGrensesnittavstemmingerRepository.insert(TidligereKjørtGrensesnittavstemming(uuid))
+
+        val lagretKjørtGrensesnittavstemming = tidligereKjørteGrensesnittavstemmingerRepository.findById(uuid)
+        Assertions.assertNotNull(lagretKjørtGrensesnittavstemming)
+    }
+
+    @Test
+    fun `Skal ikke kjøre grensesnittavstemming dersom det allerede er kjørt på samme avstemmingId`() {
+        val logger: Logger = LoggerFactory.getLogger(GrensesnittavstemmingService::class.java) as Logger
+        logger.addAppender(listAppender)
+
+        opprettUtbetalingsoppdrag()
+        every { avstemmingSender.sendGrensesnittAvstemming(any()) } returns Unit
+
+        val avstemmingId = UUID.randomUUID()
+        grensesnittavstemmingService.utførGrensesnittavstemming(
+            GrensesnittavstemmingRequest(
+                fagsystem = "BA",
+                fra = LocalDateTime.now().minusDays(2),
+                til = LocalDateTime.now(),
+                avstemmingId = avstemmingId
+            )
+        )
+
+        grensesnittavstemmingService.utførGrensesnittavstemming(
+            GrensesnittavstemmingRequest(
+                fagsystem = "BA",
+                fra = LocalDateTime.now().minusDays(2),
+                til = LocalDateTime.now(),
+                avstemmingId = avstemmingId
+            )
+        )
+
+        val fullførtMeldinger = listAppender.list.filter { "Fullført grensesnittavstemming" in it.message }
+        Assertions.assertEquals(1, fullførtMeldinger.size)
+    }
+
+    @Test
+    fun `Skal være mulig å kjøre grensesnittavstemming selv om avstemmingId er null`() {
+        val logger: Logger = LoggerFactory.getLogger(GrensesnittavstemmingService::class.java) as Logger
+        logger.addAppender(listAppender)
+
+        opprettUtbetalingsoppdrag()
+        every { avstemmingSender.sendGrensesnittAvstemming(any()) } returns Unit
+
+        grensesnittavstemmingService.utførGrensesnittavstemming(
+            GrensesnittavstemmingRequest(
+                fagsystem = "BA",
+                fra = LocalDateTime.now().minusDays(2),
+                til = LocalDateTime.now(),
+                avstemmingId = null
+            )
+        )
+
+        val fullførtMeldinger = listAppender.list.filter { "Fullført grensesnittavstemming" in it.message }
+        Assertions.assertEquals(1, fullførtMeldinger.size)
+    }
+
+    @Test
+    fun `Skal være mulig å kjøre grensesnittavstemming flere ganger når ikke avstemmingId er satt`() {
+        val logger: Logger = LoggerFactory.getLogger(GrensesnittavstemmingService::class.java) as Logger
+        logger.addAppender(listAppender)
+
+        opprettUtbetalingsoppdrag()
+        every { avstemmingSender.sendGrensesnittAvstemming(any()) } returns Unit
+
+        grensesnittavstemmingService.utførGrensesnittavstemming(
+            GrensesnittavstemmingRequest(
+                fagsystem = "BA",
+                fra = LocalDateTime.now().minusDays(2),
+                til = LocalDateTime.now(),
+                avstemmingId = null
+            )
+        )
+
+        grensesnittavstemmingService.utførGrensesnittavstemming(
+            GrensesnittavstemmingRequest(
+                fagsystem = "BA",
+                fra = LocalDateTime.now().minusDays(2),
+                til = LocalDateTime.now(),
+                avstemmingId = null
+            )
+        )
+
+        val fullførtMeldinger = listAppender.list.filter { "Fullført grensesnittavstemming" in it.message }
+        Assertions.assertEquals(2, fullførtMeldinger.size)
+    }
+
+    @Test
+    fun `Skal være mulig å kjøre grensesnittavstemming flere ganger når om man bruker forskjellig avstemmingId`() {
+        val logger: Logger = LoggerFactory.getLogger(GrensesnittavstemmingService::class.java) as Logger
+        logger.addAppender(listAppender)
+
+        opprettUtbetalingsoppdrag()
+        every { avstemmingSender.sendGrensesnittAvstemming(any()) } returns Unit
+
+        grensesnittavstemmingService.utførGrensesnittavstemming(
+            GrensesnittavstemmingRequest(
+                fagsystem = "BA",
+                fra = LocalDateTime.now().minusDays(2),
+                til = LocalDateTime.now(),
+                avstemmingId = UUID.randomUUID()
+            )
+        )
+
+        grensesnittavstemmingService.utførGrensesnittavstemming(
+            GrensesnittavstemmingRequest(
+                fagsystem = "BA",
+                fra = LocalDateTime.now().minusDays(2),
+                til = LocalDateTime.now(),
+                avstemmingId = UUID.randomUUID()
+            )
+        )
+
+        val fullførtMeldinger = listAppender.list.filter { "Fullført grensesnittavstemming" in it.message }
+        Assertions.assertEquals(2, fullførtMeldinger.size)
+    }
+
+    private fun opprettUtbetalingsoppdrag() {
+        val utbetalingsoppdrag = TestOppdragMedAvstemmingsdato.lagTestUtbetalingsoppdrag(
+            LocalDateTime.now().minusDays(1),
+            "BA",
+            utbetalingsperiode = arrayOf(TestOppdragMedAvstemmingsdato.lagUtbetalingsperiode())
+        )
+        val oppdrag = oppdragMapper.tilOppdrag(oppdragMapper.tilOppdrag110(utbetalingsoppdrag))
+        oppdragLagerRepository.opprettOppdrag(OppdragLager.lagFraOppdrag(utbetalingsoppdrag, oppdrag), 0)
+    }
+}

--- a/src/test/kotlin/no/nav/familie/oppdrag/service/GrensesnittavstemmingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/oppdrag/service/GrensesnittavstemmingServiceTest.kt
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.LocalDateTime
 import java.util.Optional
-import no.nav.familie.oppdrag.repository.TidligereKjørteGrensesnittavstemminger
+import no.nav.familie.oppdrag.repository.TidligereKjørtGrensesnittavstemming
 import no.nav.familie.oppdrag.repository.TidligereKjørteGrensesnittavstemmingerRepository
 
 class GrensesnittavstemmingServiceTest {
@@ -44,7 +44,7 @@ class GrensesnittavstemmingServiceTest {
             oppdragLagerRepository.hentIverksettingerForGrensesnittavstemming(any(), any(), any(), antall, any())
         } returns emptyList()
 
-        every { tidligereKjørteGrensesnittavstemmingerRepository.findById(any()) } returns Optional.empty<TidligereKjørteGrensesnittavstemminger>()
+        every { tidligereKjørteGrensesnittavstemmingerRepository.findById(any()) } returns Optional.empty<TidligereKjørtGrensesnittavstemming>()
 
         justRun { avstemmingSender.sendGrensesnittAvstemming(capture(slot)) }
     }


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-17773

Når vi kjører grensesnittavstemming i ba-sak henter det at avstemmingen timer ut mellom ba-sak og familie-oppdrag, selv om det går bra mot oppdrag. I de tilfellene har vi ikke lyst til å kjøre grensesnittavstemmingen på nytt.

Endrer så vi kan ta imot en avstemmingId som vi lagrer ned dersom avstemmingen går ok. Når vi prøver å rekjøre en grenseavsnittsavstemming på samme avstemmingId vil den bli ignorert om forrige avstemming var ok.