### PR TITLE
Oppdater databaseoppsettet

### DIFF
--- a/src/test/kotlin/no/nav/familie/oppdrag/repository/MellomlagringKonsistensavstemmingRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/familie/oppdrag/repository/MellomlagringKonsistensavstemmingRepositoryTest.kt
@@ -14,10 +14,14 @@ import org.springframework.test.context.ContextConfiguration
 import org.testcontainers.junit.jupiter.Container
 import org.testcontainers.junit.jupiter.Testcontainers
 import java.util.UUID
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.testcontainers.containers.PostgreSQLContainer
 import kotlin.test.assertEquals
 
 @ActiveProfiles("dev")
-@ContextConfiguration(initializers = arrayOf(Containers.PostgresSQLInitializer::class))
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @SpringBootTest(
     classes = [MellomlagringKonsistensavstemmingRepositoryTest.TestConfig::class],
     properties = ["spring.cloud.vault.enabled=false"],
@@ -29,8 +33,16 @@ internal class MellomlagringKonsistensavstemmingRepositoryTest {
     @Autowired lateinit var repository: MellomlagringKonsistensavstemmingRepository
 
     companion object {
+        @Container
+        private val postgreSQLContainer = PostgreSQLContainer<Nothing>("postgres:latest")
 
-        @Container var postgreSQLContainer = Containers.postgreSQLContainer
+        @DynamicPropertySource
+        @JvmStatic
+        fun registerDynamicProperties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url", postgreSQLContainer::getJdbcUrl)
+            registry.add("spring.datasource.username", postgreSQLContainer::getUsername)
+            registry.add("spring.datasource.password", postgreSQLContainer::getPassword)
+        }
     }
 
     @Test

--- a/src/test/kotlin/no/nav/familie/oppdrag/repository/OppdragLagerRepositoryJdbcTest.kt
+++ b/src/test/kotlin/no/nav/familie/oppdrag/repository/OppdragLagerRepositoryJdbcTest.kt
@@ -25,10 +25,14 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import java.util.UUID
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.testcontainers.containers.PostgreSQLContainer
 import kotlin.test.assertFailsWith
 
 @ActiveProfiles("dev")
-@ContextConfiguration(initializers = arrayOf(Containers.PostgresSQLInitializer::class))
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @SpringBootTest(classes = [TestConfig::class], properties = ["spring.cloud.vault.enabled=false"])
 @DisabledIfEnvironmentVariable(named = "CIRCLECI", matches = "true")
 @Testcontainers
@@ -39,8 +43,16 @@ internal class OppdragLagerRepositoryJdbcTest {
     @Autowired lateinit var jdbcTemplate: JdbcTemplate
 
     companion object {
+        @Container
+        private val postgreSQLContainer = PostgreSQLContainer<Nothing>("postgres:latest")
 
-        @Container var postgreSQLContainer = Containers.postgreSQLContainer
+        @DynamicPropertySource
+        @JvmStatic
+        fun registerDynamicProperties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url", postgreSQLContainer::getJdbcUrl)
+            registry.add("spring.datasource.username", postgreSQLContainer::getUsername)
+            registry.add("spring.datasource.password", postgreSQLContainer::getPassword)
+        }
     }
 
     @BeforeEach

--- a/src/test/kotlin/no/nav/familie/oppdrag/rest/OppdragControllerIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/familie/oppdrag/rest/OppdragControllerIntegrationTest.kt
@@ -23,10 +23,15 @@ import org.testcontainers.junit.jupiter.Container
 import org.testcontainers.junit.jupiter.Testcontainers
 import org.testcontainers.shaded.org.awaitility.Awaitility.await
 import java.time.Duration
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.testcontainers.containers.PostgreSQLContainer
 import kotlin.test.assertEquals
 
 @ActiveProfiles("dev")
-@ContextConfiguration(initializers = [Containers.PostgresSQLInitializer::class, Containers.MQInitializer::class])
+@ContextConfiguration(initializers = [ Containers.MQInitializer::class])
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @SpringBootTest(classes = [TestConfig::class], properties = ["spring.cloud.vault.enabled=false"])
 @EnableJms
 @DisabledIfEnvironmentVariable(named = "CIRCLECI", matches = "true")
@@ -38,8 +43,16 @@ internal class OppdragControllerIntegrationTest {
     @Autowired lateinit var oppdragLagerRepository: OppdragLagerRepository
 
     companion object {
+        @Container
+        private val postgreSQLContainer = PostgreSQLContainer<Nothing>("postgres:latest")
 
-        @Container var postgreSQLContainer = Containers.postgreSQLContainer
+        @DynamicPropertySource
+        @JvmStatic
+        fun registerDynamicProperties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url", postgreSQLContainer::getJdbcUrl)
+            registry.add("spring.datasource.username", postgreSQLContainer::getUsername)
+            registry.add("spring.datasource.password", postgreSQLContainer::getPassword)
+        }
 
         @Container var ibmMQContainer = Containers.ibmMQContainer
     }

--- a/src/test/kotlin/no/nav/familie/oppdrag/util/ContainerTest.kt
+++ b/src/test/kotlin/no/nav/familie/oppdrag/util/ContainerTest.kt
@@ -13,32 +13,13 @@ import org.testcontainers.containers.PostgreSQLContainer
 class TestConfig
 
 object Containers {
-
-    var postgreSQLContainer = MyPostgreSQLContainer("postgres:latest")
-        .withDatabaseName("familie-oppdrag")
-        .withUsername("postgres")
-        .withPassword("test")
-        .withExposedPorts(5432)
-
     var ibmMQContainer = MyGeneralContainer("ibmcom/mq")
         .withEnv("LICENSE", "accept")
         .withEnv("MQ_QMGR_NAME", "QM1")
         .withEnv("persistance.enabled", "true")
         .withExposedPorts(1414)
 
-    class MyPostgreSQLContainer(imageName: String) : PostgreSQLContainer<MyPostgreSQLContainer>(imageName)
     class MyGeneralContainer(imageName: String) : GenericContainer<MyGeneralContainer>(imageName)
-
-    class PostgresSQLInitializer : ApplicationContextInitializer<ConfigurableApplicationContext> {
-
-        override fun initialize(configurableApplicationContext: ConfigurableApplicationContext) {
-            TestPropertyValues.of(
-                "spring.datasource.url=" + postgreSQLContainer.jdbcUrl,
-                "spring.datasource.username=" + postgreSQLContainer.username,
-                "spring.datasource.password=" + postgreSQLContainer.password,
-            ).applyTo(configurableApplicationContext.environment)
-        }
-    }
 
     class MQInitializer : ApplicationContextInitializer<ConfigurableApplicationContext> {
 


### PR DESCRIPTION
Da vi prøvde å gjenbruke databaseoppsettet for testene gikk testene i beina på hverandre. Oppdaterer derfor testene til å bruke oppsettet i [denne guiden](https://www.wwt.com/article/using-testcontainers-for-unit-tests-with-spring-and-kotlin).

