### PR TITLE
Øker minne og cpu i prod for å være rigget for grensesnittavstemming igjen

### DIFF
--- a/app-prod.yaml
+++ b/app-prod.yaml
@@ -33,10 +33,10 @@ spec:
     max: 4
   resources:
     limits:
-      memory: 2000Mi
+      memory: 6096Mi
     requests:
       memory: 2000Mi
-      cpu: 50m
+      cpu: 500m
   secureLogs:
     enabled: true
   ingresses: # Optional. List of ingress URLs that will route HTTP traffic to the application.


### PR DESCRIPTION
Halvor skrudde ned en del minne og cpu. Reverterer dette siden vi er avhengig av mye minne for større grensesnittavstemming som skjer under satsendring