### PR TITLE
NAV-24387: Filtrere duplikate perioder ved konsistensavstemming

### DIFF
--- a/src/main/kotlin/no/nav/familie/oppdrag/service/KonsistensavstemmingService.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/service/KonsistensavstemmingService.kt
@@ -204,8 +204,8 @@ class KonsistensavstemmingService(
         this
             .groupBy { utbetalingsperiode -> utbetalingsperiode.periodeId }
             .mapValues { (_, utbetalingsperioder) ->
-                utbetalingsperioder.maxBy { utbetalingsperioder ->
-                    utbetalingsperioder.datoForVedtak
+                utbetalingsperioder.maxBy {
+                    it.datoForVedtak
                 }
             }.values
             .toList()

--- a/src/test/kotlin/no/nav/familie/oppdrag/konsistensavstemming/KonsistensavstemmingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/oppdrag/konsistensavstemming/KonsistensavstemmingServiceTest.kt
@@ -167,7 +167,7 @@ class KonsistensavstemmingServiceTest {
         assertThat(
             totalData.captured.totaldata.totalBelop
                 .toInt(),
-        ).isEqualTo(322)
+        ).isEqualTo(422)
         assertThat(
             totalData.captured.totaldata.totalAntall
                 .toInt(),

--- a/src/test/kotlin/no/nav/familie/oppdrag/konsistensavstemming/KonsistensavstemmingServiceTest.kt
+++ b/src/test/kotlin/no/nav/familie/oppdrag/konsistensavstemming/KonsistensavstemmingServiceTest.kt
@@ -135,7 +135,7 @@ class KonsistensavstemmingServiceTest {
         val perioder =
             listOf(
                 PerioderForBehandling("1", setOf(1), aktiveFødselsnummere[0], "tss-id"),
-                PerioderForBehandling("2", setOf(3), aktiveFødselsnummere[0]),
+                PerioderForBehandling("2", setOf(2, 3), aktiveFødselsnummere[0]),
             )
         val request = KonsistensavstemmingRequestV2("BA", perioder, LocalDateTime.now())
 
@@ -151,7 +151,7 @@ class KonsistensavstemmingServiceTest {
         }
 
         assertThat(oppdrag.captured.oppdragsdataListe).hasSize(1)
-        assertThat(oppdrag.captured.oppdragsdataListe[0].oppdragslinjeListe).hasSize(2)
+        assertThat(oppdrag.captured.oppdragsdataListe[0].oppdragslinjeListe).hasSize(3)
         assertThat(oppdrag.captured.oppdragsdataListe[0].oppdragGjelderId).isEqualTo(aktiveFødselsnummere[0])
         assertThat(
             oppdrag.captured.oppdragsdataListe[0]


### PR DESCRIPTION
[NAV-24387](https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=NAV-24387)

Dersom vi avkorter/opphører en eksisterende periode vil det finnes minst 2 utbetalingsperioder lagret i databasen tilknyttet fagsaken med samme periodeId. En som representerer den originale perioden og en som representerer opphøret. Frem til nå har vi sendt alle utbetalingsperioder for gitte periodeId'er uten å sjekke om det finnes duplikater ved konsistensavstemming, og dette fører til avvik.

Legger her inn filtrering av utbetalingsperiodene hvor vi sørger for at det ikke finnes duplikater, og at det er perioden med seneste `datoForVedtak` blant duplikatene vi ender opp med å sende.

Relatert slack-tråd: https://nav-it.slack.com/archives/C01ESUV8V52/p1741330236781319