### PR TITLE
Skru på logg-splitting til Elastic og Loki

### DIFF
--- a/.nais/app-dev.yaml
+++ b/.nais/app-dev.yaml
@@ -75,6 +75,10 @@ spec:
             - port: 1413
 
   observability:
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
     autoInstrumentation:
       enabled: true
       runtime: java

--- a/.nais/app-prod.yaml
+++ b/.nais/app-prod.yaml
@@ -70,6 +70,10 @@ spec:
           ports:
             - port: 1414
   observability:
+    logging:
+      destinations:
+        - id: elastic
+        - id: loki
     autoInstrumentation:
       enabled: true
       runtime: java


### PR DESCRIPTION
### 💰 Hva skal gjøres, og hvorfor?
Skrur på logg-splitting for app, som betyr at vi sender logs til både Elastic (Kibana) og (Grafana) Loki. Dette er en midlertidig løsning mens vi enda blir kjent med Loki og får satt opp ting slik vi ønsker det.

Favro: NAV-25157