### PR TITLE
Legg til notify-audit for image-deploy

### DIFF
--- a/.github/workflows/manual-deploy-with-image.yaml
+++ b/.github/workflows/manual-deploy-with-image.yaml
@@ -26,3 +26,11 @@ jobs:
       cluster: ${{ inputs.environment }}-fss
       resource: .nais/app-${{ inputs.environment }}.yaml
     secrets: inherit
+  notify-audit:
+    name: Notify if audited deploy
+    if: github.ref != 'refs/heads/main' && inputs.environment == 'prod'
+    permissions: {}
+    needs: deploy-with-existing-image
+    uses: navikt/familie-baks-gha-workflows/.github/workflows/notify-audited-deploy.yaml@main # ratchet:exclude
+    secrets:
+      BAKS_AUDIT_ALERTS_SLACK_WEBHOOK: ${{ secrets.BAKS_AUDIT_ALERTS_SLACK_WEBHOOK }}


### PR DESCRIPTION
### 📮 Favro: NAV-28509

### 💰 Hva skal gjøres, og hvorfor?
Hvis det blir deployet fra ikke-main branch varsles det i slack-kanal: #team-baks-audit-alerts. Et etterlevelsekrav og sikkerhetstiltak.