### PR TITLE
Spring security

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,6 @@
         <main-class>no.nav.familie.oppdrag.LauncherKt</main-class>
         <felles.version>4.20260428145828_c16a1d8</felles.version>
 	    <kontrakter.version>4.0_20260420135248_2e6d9ea</kontrakter.version>
-        <token-validation-spring.version>6.0.6</token-validation-spring.version>
 
         <!--
         denne må oppdateres manuellt då eks `mvn versions:update-properties` henter versjon 2023.
@@ -100,7 +99,6 @@
             <artifactId>spring-boot-starter-jdbc-test</artifactId>
             <scope>test</scope>
         </dependency>
-
         <!-- Kotlin -->
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
@@ -203,41 +201,21 @@
             <scope>test</scope>
         </dependency>
 
-        <!-- NAV interne avhengigheter-->
+        <!-- Spring Security OAuth2 Resource Server -->
         <dependency>
-            <groupId>no.nav.security</groupId>
-            <artifactId>token-client-spring</artifactId>
-            <version>${token-validation-spring.version}</version>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
         </dependency>
         <dependency>
-            <groupId>no.nav.security</groupId>
-            <artifactId>token-client-core</artifactId>
-            <version>${token-validation-spring.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>no.nav.security</groupId>
-            <artifactId>token-validation-spring</artifactId>
-            <version>${token-validation-spring.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>no.nav.security</groupId>
-            <artifactId>token-validation-spring-test</artifactId>
-            <version>${token-validation-spring.version}</version>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <!-- NAV interne avhengigheter-->
         <dependency>
             <groupId>no.nav.familie.felles</groupId>
             <artifactId>log</artifactId>
-            <version>${felles.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>no.nav.familie.felles</groupId>
-            <artifactId>sikkerhet</artifactId>
-            <version>${felles.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>no.nav.familie.felles</groupId>
-            <artifactId>sikkerhet-token-support</artifactId>
             <version>${felles.version}</version>
         </dependency>
         <dependency>
@@ -249,6 +227,11 @@
             <groupId>no.nav.familie.kontrakter</groupId>
             <artifactId>barnetrygd</artifactId>
             <version>${kontrakter.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>no.nav.familie.felles</groupId>
+            <artifactId>sikkerhet-spring-security</artifactId>
+            <version>${felles.version}</version>
         </dependency>
 
         <dependency>
@@ -406,6 +389,12 @@
             <groupId>org.testcontainers</groupId>
             <artifactId>junit-jupiter</artifactId>
             <version>${testcontainers.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>no.nav.security</groupId>
+            <artifactId>mock-oauth2-server</artifactId>
+            <version>3.0.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -399,7 +399,7 @@
         <dependency>
             <groupId>no.nav.security</groupId>
             <artifactId>mock-oauth2-server</artifactId>
-            <version>3.0.1</version>
+            <version>4.0.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,11 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webmvc-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-jdbc-test</artifactId>
             <scope>test</scope>
         </dependency>

--- a/src/main/kotlin/no/nav/familie/oppdrag/Launcher.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/Launcher.kt
@@ -1,14 +1,11 @@
 package no.nav.familie.oppdrag
 
-import no.nav.familie.sikkerhet.context.FamilieFellesNavTokenSupportKonfigurasjon
 import org.springframework.boot.SpringApplication
 import org.springframework.boot.autoconfigure.SpringBootApplication
-import org.springframework.context.annotation.Import
 import org.springframework.jms.annotation.EnableJms
 
 @SpringBootApplication
 @EnableJms
-@Import(FamilieFellesNavTokenSupportKonfigurasjon::class)
 class Launcher
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/no/nav/familie/oppdrag/config/ApiExceptionHandler.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/config/ApiExceptionHandler.kt
@@ -3,7 +3,6 @@ package no.nav.familie.oppdrag.config
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.oppdrag.common.RessursUtils.illegalState
 import no.nav.familie.oppdrag.common.RessursUtils.serviceUnavailable
-import no.nav.familie.oppdrag.common.RessursUtils.unauthorized
 import no.nav.familie.oppdrag.tss.TssConnectionException
 import no.nav.familie.oppdrag.tss.TssException
 import no.nav.familie.oppdrag.tss.TssNoDataFoundException
@@ -12,8 +11,6 @@ import org.slf4j.LoggerFactory
 import org.springframework.core.NestedExceptionUtils.getMostSpecificCause
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
-import org.springframework.security.access.AccessDeniedException
-import org.springframework.security.core.AuthenticationException
 import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ExceptionHandler
 

--- a/src/main/kotlin/no/nav/familie/oppdrag/config/ApiExceptionHandler.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/config/ApiExceptionHandler.kt
@@ -7,12 +7,13 @@ import no.nav.familie.oppdrag.common.RessursUtils.unauthorized
 import no.nav.familie.oppdrag.tss.TssConnectionException
 import no.nav.familie.oppdrag.tss.TssException
 import no.nav.familie.oppdrag.tss.TssNoDataFoundException
-import no.nav.security.token.support.spring.validation.interceptor.JwtTokenUnauthorizedException
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.core.NestedExceptionUtils.getMostSpecificCause
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.security.access.AccessDeniedException
+import org.springframework.security.core.AuthenticationException
 import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ExceptionHandler
 
@@ -20,11 +21,6 @@ import org.springframework.web.bind.annotation.ExceptionHandler
 class ApiExceptionHandler {
     private val logger: Logger = LoggerFactory.getLogger(this::class.java)
     private val secureLogger = LoggerFactory.getLogger("secureLogger")
-
-    @ExceptionHandler(JwtTokenUnauthorizedException::class)
-    fun handleJwtTokenUnauthorizedException(
-        jwtTokenUnauthorizedException: JwtTokenUnauthorizedException,
-    ): ResponseEntity<Ressurs<Nothing>> = unauthorized("Unauthorized")
 
     @ExceptionHandler(Throwable::class)
     fun handleThrowable(throwable: Throwable): ResponseEntity<Ressurs<Nothing>> {

--- a/src/main/kotlin/no/nav/familie/oppdrag/config/ApplicationConfig.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/config/ApplicationConfig.kt
@@ -3,7 +3,6 @@ package no.nav.familie.oppdrag.config
 import no.nav.familie.log.NavSystemtype
 import no.nav.familie.log.filter.LogFilter
 import no.nav.familie.log.filter.RequestTimeFilter
-import no.nav.security.token.support.spring.api.EnableJwtTokenValidation
 import org.springframework.boot.SpringBootConfiguration
 import org.springframework.boot.jetty.servlet.JettyServletWebServerFactory
 import org.springframework.boot.persistence.autoconfigure.EntityScan
@@ -11,13 +10,13 @@ import org.springframework.boot.web.server.servlet.ServletWebServerFactory
 import org.springframework.boot.web.servlet.FilterRegistrationBean
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.Import
 import org.springframework.scheduling.annotation.EnableScheduling
 
 @SpringBootConfiguration
-@EntityScan(ApplicationConfig.PAKKENAVN, "no.nav.familie.sikkerhet")
-@ComponentScan(ApplicationConfig.PAKKENAVN, "no.nav.familie.sikkerhet")
+@EntityScan(ApplicationConfig.PAKKENAVN)
+@ComponentScan(ApplicationConfig.PAKKENAVN)
 @EnableScheduling
-@EnableJwtTokenValidation(ignore = ["org.springframework", "org.springdoc"])
 class ApplicationConfig {
     @Bean
     fun servletWebServerFactory(): ServletWebServerFactory {

--- a/src/main/kotlin/no/nav/familie/oppdrag/config/SecurityConfig.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/config/SecurityConfig.kt
@@ -56,7 +56,7 @@ class SecurityConfig {
         AccessDeniedHandler { request, response, accessDeniedException ->
             logger.debug("AccessDeniedException caught: ${accessDeniedException.message}")
             // Maintains backward compatibility - returns 401 instead of 403
-            response.status = HttpStatus.UNAUTHORIZED.value()
+            response.status = HttpStatus.FORBIDDEN.value()
             response.contentType = MediaType.APPLICATION_JSON_VALUE
             response.writer.write(
                 jsonMapper.writeValueAsString(Ressurs.failure<Nothing>("Forbidden")),

--- a/src/main/kotlin/no/nav/familie/oppdrag/config/SecurityConfig.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/config/SecurityConfig.kt
@@ -1,0 +1,68 @@
+package no.nav.familie.oppdrag.config
+
+import no.nav.familie.kontrakter.felles.Ressurs
+import no.nav.familie.kontrakter.felles.jsonMapper
+import no.nav.familie.sikkerhet.context.FamilieFellesSpringSecurityKonfigurasjon
+import org.slf4j.LoggerFactory
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Import
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.config.annotation.web.invoke
+import org.springframework.security.web.AuthenticationEntryPoint
+import org.springframework.security.web.SecurityFilterChain
+import org.springframework.security.web.access.AccessDeniedHandler
+
+@Configuration
+@EnableWebSecurity
+@Import(FamilieFellesSpringSecurityKonfigurasjon::class)
+class SecurityConfig {
+    private val logger = LoggerFactory.getLogger(SecurityConfig::class.java)
+
+    @Bean
+    fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
+        http {
+            authorizeHttpRequests {
+                authorize("/internal/**", permitAll)
+                authorize("/v3/api-docs/**", permitAll)
+                authorize("/swagger-ui/**", permitAll)
+                authorize("/swagger-ui.html", permitAll)
+                authorize(anyRequest, authenticated)
+            }
+            oauth2ResourceServer {
+                jwt { }
+                authenticationEntryPoint = authenticationEntryPoint()
+                accessDeniedHandler = accessDeniedHandler()
+            }
+
+
+        }
+        return http.build()
+    }
+
+    private fun authenticationEntryPoint() =
+        AuthenticationEntryPoint { request, response, authException ->
+            logger.debug("AuthenticationException caught: ${authException.message}")
+            response.status = HttpStatus.UNAUTHORIZED.value()
+            response.contentType = MediaType.APPLICATION_JSON_VALUE
+            response.writer.write(
+                jsonMapper.writeValueAsString(Ressurs.failure<Nothing>("Unauthorized")),
+            )
+            response.writer.flush()
+        }
+
+    private fun accessDeniedHandler() =
+        AccessDeniedHandler { request, response, accessDeniedException ->
+            logger.debug("AccessDeniedException caught: ${accessDeniedException.message}")
+            // Maintains backward compatibility - returns 401 instead of 403
+            response.status = HttpStatus.UNAUTHORIZED.value()
+            response.contentType = MediaType.APPLICATION_JSON_VALUE
+            response.writer.write(
+                jsonMapper.writeValueAsString(Ressurs.failure<Nothing>("Forbidden")),
+            )
+            response.writer.flush()
+        }
+}

--- a/src/main/kotlin/no/nav/familie/oppdrag/config/SecurityConfig.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/config/SecurityConfig.kt
@@ -37,8 +37,6 @@ class SecurityConfig {
                 authenticationEntryPoint = authenticationEntryPoint()
                 accessDeniedHandler = accessDeniedHandler()
             }
-
-
         }
         return http.build()
     }

--- a/src/main/kotlin/no/nav/familie/oppdrag/rest/AvstemmingController.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/rest/AvstemmingController.kt
@@ -10,7 +10,6 @@ import no.nav.familie.oppdrag.repository.UtbetalingsoppdragForKonsistensavstemmi
 import no.nav.familie.oppdrag.service.Fagsystem
 import no.nav.familie.oppdrag.service.GrensesnittavstemmingService
 import no.nav.familie.oppdrag.service.KonsistensavstemmingService
-import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
@@ -27,7 +26,6 @@ import java.util.UUID
 
 @RestController
 @RequestMapping("/api")
-@ProtectedWithClaims(issuer = "azuread")
 @Validated
 class AvstemmingController(
     @Autowired val grensesnittavstemmingService: GrensesnittavstemmingService,

--- a/src/main/kotlin/no/nav/familie/oppdrag/rest/OppdragController.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/rest/OppdragController.kt
@@ -15,7 +15,6 @@ import no.nav.familie.oppdrag.iverksetting.OppdragMapper
 import no.nav.familie.oppdrag.service.OppdragAlleredeSendtException
 import no.nav.familie.oppdrag.service.OppdragHarAlleredeKvitteringException
 import no.nav.familie.oppdrag.service.OppdragService
-import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.MediaType
@@ -30,7 +29,6 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/api")
-@ProtectedWithClaims(issuer = "azuread")
 class OppdragController(
     @Autowired val oppdragService: OppdragService,
     @Autowired val oppdragMapper: OppdragMapper,

--- a/src/main/kotlin/no/nav/familie/oppdrag/rest/SimuleringController.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/rest/SimuleringController.kt
@@ -8,7 +8,6 @@ import no.nav.familie.kontrakter.felles.simulering.FeilutbetalingerFraSimulering
 import no.nav.familie.kontrakter.felles.simulering.HentFeilutbetalingerFraSimuleringRequest
 import no.nav.familie.oppdrag.common.RessursUtils.ok
 import no.nav.familie.oppdrag.simulering.SimuleringTjeneste
-import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
@@ -25,7 +24,6 @@ import org.springframework.web.bind.annotation.RestController
     consumes = [MediaType.APPLICATION_JSON_VALUE],
     produces = [MediaType.APPLICATION_JSON_VALUE],
 )
-@ProtectedWithClaims(issuer = "azuread")
 class SimuleringController(
     @Autowired val simuleringTjeneste: SimuleringTjeneste,
 ) {

--- a/src/main/kotlin/no/nav/familie/oppdrag/rest/TilbakekrevingController.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/rest/TilbakekrevingController.kt
@@ -9,7 +9,6 @@ import no.nav.okonomi.tilbakekrevingservice.KravgrunnlagHentDetaljRequest
 import no.nav.okonomi.tilbakekrevingservice.KravgrunnlagHentDetaljResponse
 import no.nav.okonomi.tilbakekrevingservice.TilbakekrevingsvedtakRequest
 import no.nav.okonomi.tilbakekrevingservice.TilbakekrevingsvedtakResponse
-import no.nav.security.token.support.core.api.ProtectedWithClaims
 import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -21,7 +20,6 @@ import java.util.UUID
 
 @RestController
 @RequestMapping("/api/tilbakekreving")
-@ProtectedWithClaims(issuer = "azuread")
 class TilbakekrevingController(
     private val økonomiClient: ØkonomiClient,
 ) {

--- a/src/main/kotlin/no/nav/familie/oppdrag/tss/TssController.kt
+++ b/src/main/kotlin/no/nav/familie/oppdrag/tss/TssController.kt
@@ -5,7 +5,6 @@ import no.nav.familie.kontrakter.ba.tss.SamhandlerInfo
 import no.nav.familie.kontrakter.ba.tss.SøkSamhandlerInfo
 import no.nav.familie.kontrakter.ba.tss.SøkSamhandlerInfoRequest
 import no.nav.familie.kontrakter.felles.Ressurs
-import no.nav.security.token.support.core.api.ProtectedWithClaims
 import no.rtv.namespacetss.TOutputElementer
 import no.rtv.namespacetss.TypeOD910
 import org.springframework.web.bind.annotation.GetMapping
@@ -17,7 +16,6 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/api/tss")
-@ProtectedWithClaims(issuer = "azuread")
 class TssController(
     private val tssOppslagService: TssOppslagService,
 ) {

--- a/src/main/resources/application-e2e.yaml
+++ b/src/main/resources/application-e2e.yaml
@@ -1,7 +1,18 @@
-no.nav.security.jwt:
-  issuer.azuread:
-    discoveryurl: http://mock-oauth2-server:1111/v2.0/.well-known/openid-configuration
-    accepted_audience: api://${OPPDRAG_CLIENT_ID}/.default
+spring:
+  datasource:
+    url: jdbc:postgresql://postgres-oppdrag:5432/familieoppdrag
+    username: familie
+    password: familie-pwd
+  cloud:
+    vault:
+      database:
+        role: familie
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri: http://mock-oauth2-server:1111/v2.0
+          audiences: api://${OPPDRAG_CLIENT_ID}/.default
 
 oppdrag.mq:
   queuemanager: QM1
@@ -14,16 +25,6 @@ oppdrag.mq:
   user: admin
   password: passw0rd
   enabled: true
-
-spring:
-  datasource:
-    url: jdbc:postgresql://postgres-oppdrag:5432/familieoppdrag
-    username: familie
-    password: familie-pwd
-  cloud:
-    vault:
-      database:
-        role: familie
 
 vault:
   systembruker:

--- a/src/main/resources/application-preprod.yaml
+++ b/src/main/resources/application-preprod.yaml
@@ -9,14 +9,6 @@ oppdrag.mq:
   port: 1413
   enabled: true
 
-
-
-no.nav.security.jwt:
-  issuer.azuread:
-    discoveryurl: ${AZURE_APP_WELL_KNOWN_URL}
-    accepted_audience: ${AZURE_APP_CLIENT_ID}
-    proxyurl: http://webproxy-nais.nav.no:8088
-
 spring:
   datasource:
     url: jdbc:postgresql://b27dbvl031.preprod.local:5432/familie-oppdrag-15

--- a/src/main/resources/application-prod.yaml
+++ b/src/main/resources/application-prod.yaml
@@ -9,12 +9,6 @@ oppdrag.mq:
   port: 1414
   enabled: true
 
-no.nav.security.jwt:
-  issuer.azuread:
-    discoveryurl: ${AZURE_APP_WELL_KNOWN_URL}
-    accepted_audience: ${AZURE_APP_CLIENT_ID}
-    proxyurl: http://webproxy-nais.nav.no:8088
-
 spring:
   datasource:
     url: jdbc:postgresql://A01DBVL035.adeo.no:5432/familie-oppdrag-15

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -29,7 +29,7 @@ spring:
     oauth2:
       resourceserver:
         jwt:
-          issuer-uri: ${AZURE_APP_WELL_KNOWN_URL}
+          issuer-uri: ${AZURE_OPENID_CONFIG_ISSUER}
           audiences: ${AZURE_APP_CLIENT_ID}
 
 management:
@@ -69,4 +69,5 @@ EF_SAK_CLIENT_ID: ""
 EF_IVERKSETT_CLIENT_ID: ""
 TILBAKEKREVING_V1_URL: "http://localhost"
 FAMILIE_TILBAKE_CLIENT_ID: ""
-AZURE_APP_WELL_KNOWN_URL: ""
+AZURE_OPENID_CONFIG_ISSUER: ""
+AZURE_APP_CLIENT_ID: ""

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -25,6 +25,12 @@ spring:
       max-lifetime: 30000
       minimum-idle: 1
       data-source-properties.stringtype: unspecified # Nødvendig for å kunde sende en String til et json-felt i PostgresSql
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri: ${AZURE_APP_WELL_KNOWN_URL}
+          audiences: ${AZURE_APP_CLIENT_ID}
 
 management:
   endpoint:

--- a/src/test/kotlin/no/nav/familie/oppdrag/config/JwtTokenTestUtil.kt
+++ b/src/test/kotlin/no/nav/familie/oppdrag/config/JwtTokenTestUtil.kt
@@ -1,0 +1,58 @@
+package no.nav.familie.oppdrag.config
+
+import no.nav.security.mock.oauth2.MockOAuth2Server
+
+object JwtTokenTestUtil {
+    fun lagAzureAdToken(
+        mockOAuth2Server: MockOAuth2Server,
+        subject: String = "test-user@nav.no",
+        audience: String = "aud-localhost",
+        groups: List<String> = emptyList(),
+        tilleggsClaims: Map<String, Any> = emptyMap(),
+    ): String =
+        mockOAuth2Server
+            .issueToken(
+                issuerId = "azuread",
+                subject = subject,
+                audience = audience,
+                claims = mapOf("groups" to groups, "preferred_username" to subject) + tilleggsClaims,
+            ).serialize()
+
+    fun lagUtgaattToken(
+        mockOAuth2Server: MockOAuth2Server,
+        subject: String = "test-user@nav.no",
+        audience: String = "aud-localhost",
+    ): String {
+        val expiry = System.currentTimeMillis() / 1000 - 3600 // 1 time siden
+        return mockOAuth2Server
+            .issueToken(
+                issuerId = "azuread",
+                subject = subject,
+                audience = audience,
+                expiry = expiry,
+            ).serialize()
+    }
+
+    fun lagTokenMedFeilIssuer(
+        mockOAuth2Server: MockOAuth2Server,
+        subject: String = "test-user@nav.no",
+        audience: String = "aud-localhost",
+    ): String =
+        mockOAuth2Server
+            .issueToken(
+                issuerId = "wrong-issuer",
+                subject = subject,
+                audience = audience,
+            ).serialize()
+
+    fun lagTokenMedFeilAudience(
+        mockOAuth2Server: MockOAuth2Server,
+        subject: String = "test-user@nav.no",
+    ): String =
+        mockOAuth2Server
+            .issueToken(
+                issuerId = "azuread",
+                subject = subject,
+                audience = "wrong-audience",
+            ).serialize()
+}

--- a/src/test/kotlin/no/nav/familie/oppdrag/config/JwtTokenTestUtil.kt
+++ b/src/test/kotlin/no/nav/familie/oppdrag/config/JwtTokenTestUtil.kt
@@ -22,16 +22,14 @@ object JwtTokenTestUtil {
         mockOAuth2Server: MockOAuth2Server,
         subject: String = "test-user@nav.no",
         audience: String = "aud-localhost",
-    ): String {
-        val expiry = System.currentTimeMillis() / 1000 - 3600 // 1 time siden
-        return mockOAuth2Server
+    ): String =
+        mockOAuth2Server
             .issueToken(
                 issuerId = "azuread",
                 subject = subject,
                 audience = audience,
-                expiry = expiry,
+                expiry = -3600, // token utløpt for 1 time siden
             ).serialize()
-    }
 
     fun lagTokenMedFeilIssuer(
         mockOAuth2Server: MockOAuth2Server,

--- a/src/test/kotlin/no/nav/familie/oppdrag/config/JwtTokenTestUtil.kt
+++ b/src/test/kotlin/no/nav/familie/oppdrag/config/JwtTokenTestUtil.kt
@@ -3,54 +3,21 @@ package no.nav.familie.oppdrag.config
 import no.nav.security.mock.oauth2.MockOAuth2Server
 
 object JwtTokenTestUtil {
-    fun lagAzureAdToken(
+    fun lagToken(
         mockOAuth2Server: MockOAuth2Server,
+        issuer: String = "azuread",
         subject: String = "test-user@nav.no",
         audience: String = "aud-localhost",
         groups: List<String> = emptyList(),
         tilleggsClaims: Map<String, Any> = emptyMap(),
+        expiry: Long = 3600
     ): String =
         mockOAuth2Server
             .issueToken(
-                issuerId = "azuread",
+                issuerId = issuer,
                 subject = subject,
                 audience = audience,
                 claims = mapOf("groups" to groups, "preferred_username" to subject) + tilleggsClaims,
-            ).serialize()
-
-    fun lagUtgaattToken(
-        mockOAuth2Server: MockOAuth2Server,
-        subject: String = "test-user@nav.no",
-        audience: String = "aud-localhost",
-    ): String =
-        mockOAuth2Server
-            .issueToken(
-                issuerId = "azuread",
-                subject = subject,
-                audience = audience,
-                expiry = -3600, // token utløpt for 1 time siden
-            ).serialize()
-
-    fun lagTokenMedFeilIssuer(
-        mockOAuth2Server: MockOAuth2Server,
-        subject: String = "test-user@nav.no",
-        audience: String = "aud-localhost",
-    ): String =
-        mockOAuth2Server
-            .issueToken(
-                issuerId = "wrong-issuer",
-                subject = subject,
-                audience = audience,
-            ).serialize()
-
-    fun lagTokenMedFeilAudience(
-        mockOAuth2Server: MockOAuth2Server,
-        subject: String = "test-user@nav.no",
-    ): String =
-        mockOAuth2Server
-            .issueToken(
-                issuerId = "azuread",
-                subject = subject,
-                audience = "wrong-audience",
+                expiry = expiry
             ).serialize()
 }

--- a/src/test/kotlin/no/nav/familie/oppdrag/config/MockOAuth2ServerInitializer.kt
+++ b/src/test/kotlin/no/nav/familie/oppdrag/config/MockOAuth2ServerInitializer.kt
@@ -18,7 +18,7 @@ class MockOAuth2ServerInitializer : ApplicationContextInitializer<ConfigurableAp
     override fun initialize(applicationContext: ConfigurableApplicationContext) {
         val properties =
             mapOf<String, Any>(
-                "AZURE_APP_WELL_KNOWN_URL" to server.issuerUrl("azuread").toString(),
+                "AZURE_OPENID_CONFIG_ISSUER" to server.issuerUrl("azuread").toString(),
                 "AZURE_APP_CLIENT_ID" to "aud-localhost",
             )
 

--- a/src/test/kotlin/no/nav/familie/oppdrag/config/MockOAuth2ServerInitializer.kt
+++ b/src/test/kotlin/no/nav/familie/oppdrag/config/MockOAuth2ServerInitializer.kt
@@ -1,0 +1,30 @@
+package no.nav.familie.oppdrag.config
+
+import no.nav.security.mock.oauth2.MockOAuth2Server
+import org.springframework.context.ApplicationContextInitializer
+import org.springframework.context.ConfigurableApplicationContext
+import org.springframework.core.env.MapPropertySource
+
+class MockOAuth2ServerInitializer : ApplicationContextInitializer<ConfigurableApplicationContext> {
+    companion object {
+        private val server: MockOAuth2Server by lazy {
+            MockOAuth2Server().also { server ->
+                server.start()
+                Runtime.getRuntime().addShutdownHook(Thread { server.shutdown() })
+            }
+        }
+    }
+
+    override fun initialize(applicationContext: ConfigurableApplicationContext) {
+        val properties =
+            mapOf<String, Any>(
+                "AZURE_APP_WELL_KNOWN_URL" to server.issuerUrl("azuread").toString(),
+                "AZURE_APP_CLIENT_ID" to "aud-localhost",
+            )
+
+        applicationContext.environment.propertySources.addFirst(
+            MapPropertySource("mockOAuth2Server", properties),
+        )
+        applicationContext.beanFactory.registerSingleton("mockOAuth2Server", server)
+    }
+}

--- a/src/test/kotlin/no/nav/familie/oppdrag/config/SecurityIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/familie/oppdrag/config/SecurityIntegrationTest.kt
@@ -3,15 +3,14 @@ package no.nav.familie.oppdrag.config
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.felles.jsonMapper
 import no.nav.security.mock.oauth2.MockOAuth2Server
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.SpringBootConfiguration
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration
 import org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
-import org.springframework.context.annotation.Import
 import org.springframework.http.MediaType
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.ContextConfiguration
@@ -22,18 +21,14 @@ import tools.jackson.module.kotlin.readValue
 
 @SpringBootTest(
     webEnvironment = SpringBootTest.WebEnvironment.MOCK,
-    classes = [SecurityIntegrationTest.TestConfig::class],
+    classes = [SecurityIntegrationTest::class, SecurityConfig::class],
     properties = ["management.endpoint.health.validate-group-membership=false"],
 )
 @AutoConfigureMockMvc
-@ActiveProfiles("dev", "security-test")
+@ActiveProfiles("dev")
 @ContextConfiguration(initializers = [MockOAuth2ServerInitializer::class])
+@EnableAutoConfiguration(exclude = [DataSourceAutoConfiguration::class])
 class SecurityIntegrationTest {
-    @SpringBootConfiguration
-    @EnableAutoConfiguration(exclude = [DataSourceAutoConfiguration::class])
-    @Import(SecurityConfig::class)
-    @org.springframework.context.annotation.Profile("security-test")
-    class TestConfig
 
     @Autowired
     private lateinit var mockMvc: MockMvc
@@ -93,12 +88,12 @@ class SecurityIntegrationTest {
                         .post("/api/simulering/v1")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(gyldigSimuleringRequest()),
-                ).andExpect(MockMvcResultMatchers.status().isUnauthorized)
+                ).andExpect(MockMvcResultMatchers.status().isForbidden)
         }
 
         @Test
         fun `skal akseptere gyldig Azure AD-token`() {
-            val token = JwtTokenTestUtil.lagAzureAdToken(mockOAuth2Server)
+            val token = JwtTokenTestUtil.lagToken(mockOAuth2Server)
 
             mockMvc
                 .perform(
@@ -114,7 +109,7 @@ class SecurityIntegrationTest {
 
         @Test
         fun `skal avvise utgått token`() {
-            val token = JwtTokenTestUtil.lagUtgaattToken(mockOAuth2Server)
+            val token = JwtTokenTestUtil.lagToken(mockOAuth2Server, expiry = -3600)
 
             mockMvc
                 .perform(
@@ -128,7 +123,7 @@ class SecurityIntegrationTest {
 
         @Test
         fun `skal avvise token med feil issuer`() {
-            val token = JwtTokenTestUtil.lagTokenMedFeilIssuer(mockOAuth2Server)
+            val token = JwtTokenTestUtil.lagToken(mockOAuth2Server, issuer = "feil-issuer")
             mockMvc
                 .perform(
                     MockMvcRequestBuilders
@@ -139,13 +134,13 @@ class SecurityIntegrationTest {
                 ).andExpect(MockMvcResultMatchers.status().isUnauthorized)
                 .andExpect {
                     val content = jsonMapper.readValue<Ressurs<Any>>(it.response.contentAsString)
-                    content.status == Ressurs.Status.FEILET
+                    assertThat(content.status).isEqualTo(Ressurs.Status.FEILET)
                 }
         }
 
         @Test
         fun `skal avvise token med feil audience`() {
-            val token = JwtTokenTestUtil.lagTokenMedFeilAudience(mockOAuth2Server)
+            val token = JwtTokenTestUtil.lagToken(mockOAuth2Server, audience = "feil-audience")
 
             mockMvc
                 .perform(
@@ -157,7 +152,7 @@ class SecurityIntegrationTest {
                 ).andExpect(MockMvcResultMatchers.status().isUnauthorized)
                 .andExpect {
                     val content = jsonMapper.readValue<Ressurs<Any>>(it.response.contentAsString)
-                    content.status == Ressurs.Status.FEILET
+                    assertThat(content.status).isEqualTo(Ressurs.Status.FEILET)
                 }
         }
     }

--- a/src/test/kotlin/no/nav/familie/oppdrag/config/SecurityIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/familie/oppdrag/config/SecurityIntegrationTest.kt
@@ -1,0 +1,207 @@
+package no.nav.familie.oppdrag.config
+
+import no.nav.familie.kontrakter.felles.Ressurs
+import no.nav.familie.kontrakter.felles.jsonMapper
+import no.nav.security.mock.oauth2.MockOAuth2Server
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.springframework.web.context.WebApplicationContext
+import org.testcontainers.junit.jupiter.Testcontainers
+import tools.jackson.module.kotlin.readValue
+
+@ActiveProfiles("dev")
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.MOCK,
+    properties = [
+        "spring.cloud.vault.enabled=false",
+        "AZURE_APP_CLIENT_ID=test-client-id",
+        "OPPDRAG_SERVICE_URL=http://localhost:8080/oppdrag-service",
+        "oppdrag.mq.enabled=false",
+    ],
+)
+@ContextConfiguration(initializers = [MockOAuth2ServerInitializer::class])
+@Testcontainers
+class SecurityIntegrationTest {
+    @Autowired
+    private lateinit var webApplicationContext: WebApplicationContext
+
+    private lateinit var mockMvc: MockMvc
+
+    @Autowired
+    private lateinit var mockOAuth2Server: MockOAuth2Server
+
+    @BeforeEach
+    fun setup() {
+        mockMvc =
+            MockMvcBuilders
+                .webAppContextSetup(webApplicationContext)
+                .apply<org.springframework.test.web.servlet.setup.DefaultMockMvcBuilder>(springSecurity())
+                .build()
+    }
+
+    private fun gyldigSimuleringRequest() =
+        """
+        {
+          "kodeEndring": "NY",
+          "fagSystem": "BA",
+          "saksnummer": "TEST-123",
+          "aktoer": "12345678901",
+          "saksbehandlerId": "TEST-USER",
+          "avstemmingTidspunkt": "2025-05-12T10:00:00",
+          "utbetalingsperiode": []
+        }
+        """.trimIndent()
+
+    @Nested
+    inner class OffentligeEndepunkter {
+        @Test
+        fun `skal tillate tilgang til health uten token`() {
+            // Health endpoint should not require auth (503 acceptable due to MQ unavailable in tests)
+            val result =
+                mockMvc
+                    .perform(MockMvcRequestBuilders.get("/internal/health"))
+                    .andReturn()
+
+            val status = result.response.status
+            assert(status != HttpStatus.UNAUTHORIZED.value()) {
+                "Health burde ikke gi 401, fikk $status"
+            }
+            assert(status != HttpStatus.FORBIDDEN.value()) {
+                "Health burde ikke gi 403, fikk $status"
+            }
+        }
+
+        @Test
+        fun `skal tillate tilgang til actuator uten token`() {
+            mockMvc
+                .perform(MockMvcRequestBuilders.get("/internal/prometheus"))
+                .andExpect(MockMvcResultMatchers.status().isOk)
+        }
+
+        @Test
+        fun `skal tillate tilgang til swagger-ui uten token`() {
+            val result =
+                mockMvc
+                    .perform(MockMvcRequestBuilders.get("/swagger-ui.html"))
+                    .andReturn()
+
+            val status = result.response.status
+            assert(status != HttpStatus.UNAUTHORIZED.value()) {
+                "Swagger burde ikke gi 401, fikk $status"
+            }
+            assert(status != HttpStatus.FORBIDDEN.value()) {
+                "Swagger burde ikke gi 403, fikk $status"
+            }
+        }
+
+        @Test
+        fun `skal tillate tilgang til api-docs uten token`() {
+            mockMvc
+                .perform(MockMvcRequestBuilders.get("/v3/api-docs"))
+                .andExpect(MockMvcResultMatchers.status().isOk)
+        }
+    }
+
+    @Nested
+    inner class BeskyttedeEndepunkter {
+        @Test
+        fun `skal avvise simulering uten token`() {
+            mockMvc
+                .perform(
+                    MockMvcRequestBuilders
+                        .post("/api/simulering/v1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(gyldigSimuleringRequest()),
+                ).andExpect(MockMvcResultMatchers.status().isUnauthorized)
+        }
+
+        @Test
+        fun `skal akseptere gyldig Azure AD-token`() {
+            val token = JwtTokenTestUtil.lagAzureAdToken(mockOAuth2Server)
+
+            // Forventer ikke 401/403 - kan være 400/500 på grunn av validering/business logic
+            val result =
+                mockMvc
+                    .perform(
+                        MockMvcRequestBuilders
+                            .post("/api/simulering/v1")
+                            .header("Authorization", "Bearer $token")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(gyldigSimuleringRequest()),
+                    ).andReturn()
+
+            val status = result.response.status
+            assert(status != HttpStatus.UNAUTHORIZED.value() && status != HttpStatus.FORBIDDEN.value()) {
+                "Gyldig token burde ikke gi 401 eller 403, fikk $status"
+            }
+        }
+
+        @Test
+        fun `skal avvise utgått token`() {
+            val token = JwtTokenTestUtil.lagUtgaattToken(mockOAuth2Server)
+
+            // Expired tokens should be rejected by auth layer (not 200 OK)
+            val result =
+                mockMvc
+                    .perform(
+                        MockMvcRequestBuilders
+                            .post("/api/simulering/v1")
+                            .header("Authorization", "Bearer $token")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(gyldigSimuleringRequest()),
+                    ).andReturn()
+
+            val status = result.response.status
+            assert(status != HttpStatus.OK.value()) {
+                "Expired token should be rejected, got status $status"
+            }
+        }
+
+        @Test
+        fun `skal avvise token med feil issuer`() {
+            val token = JwtTokenTestUtil.lagTokenMedFeilIssuer(mockOAuth2Server)
+            mockMvc
+                .perform(
+                    MockMvcRequestBuilders
+                        .post("/api/simulering/v1")
+                        .header("Authorization", "Bearer $token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(gyldigSimuleringRequest()),
+                ).andExpect(MockMvcResultMatchers.status().isUnauthorized)
+                .andExpect {
+                    val content = jsonMapper.readValue<Ressurs<Any>>(it.response.contentAsString)
+                    content.status == Ressurs.Status.FEILET
+                }
+        }
+
+        @Test
+        fun `skal avvise token med feil audience`() {
+            val token = JwtTokenTestUtil.lagTokenMedFeilAudience(mockOAuth2Server)
+
+            mockMvc
+                .perform(
+                    MockMvcRequestBuilders
+                        .post("/api/simulering/v1")
+                        .header("Authorization", "Bearer $token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(gyldigSimuleringRequest()),
+                ).andExpect(MockMvcResultMatchers.status().isUnauthorized)
+                .andExpect {
+                    val content = jsonMapper.readValue<Ressurs<Any>>(it.response.contentAsString)
+                    content.status == Ressurs.Status.FEILET
+                }
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/familie/oppdrag/config/SecurityIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/familie/oppdrag/config/SecurityIntegrationTest.kt
@@ -3,53 +3,43 @@ package no.nav.familie.oppdrag.config
 import no.nav.familie.kontrakter.felles.Ressurs
 import no.nav.familie.kontrakter.felles.jsonMapper
 import no.nav.security.mock.oauth2.MockOAuth2Server
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.SpringBootConfiguration
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration
+import org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.http.HttpStatus
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.context.annotation.Import
 import org.springframework.http.MediaType
-import org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.ContextConfiguration
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers
-import org.springframework.test.web.servlet.setup.MockMvcBuilders
-import org.springframework.web.context.WebApplicationContext
-import org.testcontainers.junit.jupiter.Testcontainers
 import tools.jackson.module.kotlin.readValue
 
-@ActiveProfiles("dev")
 @SpringBootTest(
     webEnvironment = SpringBootTest.WebEnvironment.MOCK,
-    properties = [
-        "spring.cloud.vault.enabled=false",
-        "AZURE_APP_CLIENT_ID=test-client-id",
-        "OPPDRAG_SERVICE_URL=http://localhost:8080/oppdrag-service",
-        "oppdrag.mq.enabled=false",
-    ],
+    classes = [SecurityIntegrationTest.TestConfig::class],
+    properties = ["management.endpoint.health.validate-group-membership=false"],
 )
+@AutoConfigureMockMvc
+@ActiveProfiles("dev", "security-test")
 @ContextConfiguration(initializers = [MockOAuth2ServerInitializer::class])
-@Testcontainers
 class SecurityIntegrationTest {
-    @Autowired
-    private lateinit var webApplicationContext: WebApplicationContext
+    @SpringBootConfiguration
+    @EnableAutoConfiguration(exclude = [DataSourceAutoConfiguration::class])
+    @Import(SecurityConfig::class)
+    @org.springframework.context.annotation.Profile("security-test")
+    class TestConfig
 
+    @Autowired
     private lateinit var mockMvc: MockMvc
 
     @Autowired
     private lateinit var mockOAuth2Server: MockOAuth2Server
-
-    @BeforeEach
-    fun setup() {
-        mockMvc =
-            MockMvcBuilders
-                .webAppContextSetup(webApplicationContext)
-                .apply<org.springframework.test.web.servlet.setup.DefaultMockMvcBuilder>(springSecurity())
-                .build()
-    }
 
     private fun gyldigSimuleringRequest() =
         """
@@ -68,19 +58,9 @@ class SecurityIntegrationTest {
     inner class OffentligeEndepunkter {
         @Test
         fun `skal tillate tilgang til health uten token`() {
-            // Health endpoint should not require auth (503 acceptable due to MQ unavailable in tests)
-            val result =
-                mockMvc
-                    .perform(MockMvcRequestBuilders.get("/internal/health"))
-                    .andReturn()
-
-            val status = result.response.status
-            assert(status != HttpStatus.UNAUTHORIZED.value()) {
-                "Health burde ikke gi 401, fikk $status"
-            }
-            assert(status != HttpStatus.FORBIDDEN.value()) {
-                "Health burde ikke gi 403, fikk $status"
-            }
+            mockMvc
+                .perform(MockMvcRequestBuilders.get("/internal/health"))
+                .andExpect(MockMvcResultMatchers.status().isOk)
         }
 
         @Test
@@ -92,25 +72,14 @@ class SecurityIntegrationTest {
 
         @Test
         fun `skal tillate tilgang til swagger-ui uten token`() {
-            val result =
-                mockMvc
-                    .perform(MockMvcRequestBuilders.get("/swagger-ui.html"))
-                    .andReturn()
-
-            val status = result.response.status
-            assert(status != HttpStatus.UNAUTHORIZED.value()) {
-                "Swagger burde ikke gi 401, fikk $status"
-            }
-            assert(status != HttpStatus.FORBIDDEN.value()) {
-                "Swagger burde ikke gi 403, fikk $status"
-            }
+            mockMvc
+                .perform(MockMvcRequestBuilders.get("/swagger-ui/index.html"))
+                .andExpect(MockMvcResultMatchers.status().isOk)
         }
 
         @Test
         fun `skal tillate tilgang til api-docs uten token`() {
-            mockMvc
-                .perform(MockMvcRequestBuilders.get("/v3/api-docs"))
-                .andExpect(MockMvcResultMatchers.status().isOk)
+            mockMvc.perform(MockMvcRequestBuilders.get("/v3/api-docs")).andExpect(MockMvcResultMatchers.status().isOk)
         }
     }
 
@@ -131,42 +100,30 @@ class SecurityIntegrationTest {
         fun `skal akseptere gyldig Azure AD-token`() {
             val token = JwtTokenTestUtil.lagAzureAdToken(mockOAuth2Server)
 
-            // Forventer ikke 401/403 - kan være 400/500 på grunn av validering/business logic
-            val result =
-                mockMvc
-                    .perform(
-                        MockMvcRequestBuilders
-                            .post("/api/simulering/v1")
-                            .header("Authorization", "Bearer $token")
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content(gyldigSimuleringRequest()),
-                    ).andReturn()
-
-            val status = result.response.status
-            assert(status != HttpStatus.UNAUTHORIZED.value() && status != HttpStatus.FORBIDDEN.value()) {
-                "Gyldig token burde ikke gi 401 eller 403, fikk $status"
-            }
+            mockMvc
+                .perform(
+                    MockMvcRequestBuilders
+                        .post("/api/simulering/v1")
+                        .header("Authorization", "Bearer $token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(gyldigSimuleringRequest()),
+                )
+                // testen laster ikke handlere så 404 er ok, forventer bare å ikke få 401 eller 403
+                .andExpect(MockMvcResultMatchers.status().isNotFound)
         }
 
         @Test
         fun `skal avvise utgått token`() {
             val token = JwtTokenTestUtil.lagUtgaattToken(mockOAuth2Server)
 
-            // Expired tokens should be rejected by auth layer (not 200 OK)
-            val result =
-                mockMvc
-                    .perform(
-                        MockMvcRequestBuilders
-                            .post("/api/simulering/v1")
-                            .header("Authorization", "Bearer $token")
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content(gyldigSimuleringRequest()),
-                    ).andReturn()
-
-            val status = result.response.status
-            assert(status != HttpStatus.OK.value()) {
-                "Expired token should be rejected, got status $status"
-            }
+            mockMvc
+                .perform(
+                    MockMvcRequestBuilders
+                        .post("/api/simulering/v1")
+                        .header("Authorization", "Bearer $token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(gyldigSimuleringRequest()),
+                ).andExpect(MockMvcResultMatchers.status().isUnauthorized)
         }
 
         @Test

--- a/src/test/resources/application-dev.yaml
+++ b/src/test/resources/application-dev.yaml
@@ -12,14 +12,17 @@ oppdrag.mq:
 grensesnitt:
   antall: 2
 
-no.nav.security.jwt:
-  issuer.azuread:
-    discoveryurl: ${AZURE_APP_WELL_KNOWN_URL}
-    accepted_audience: ${AZURE_APP_CLIENT_ID}
-
-spring.datasource.url: jdbc:postgresql://0.0.0.0:5432/familie-oppdrag
-spring.datasource.username: postgres
-spring.datasource.password: test
+spring:
+  datasource:
+    url: jdbc:postgresql://0.0.0.0:5432/familie-oppdrag
+    username: postgres
+    password: test
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri: ${AZURE_APP_WELL_KNOWN_URL}
+          audiences: ${AZURE_APP_CLIENT_ID}
 
 vault:
   systembruker:

--- a/src/test/resources/application-dev.yaml
+++ b/src/test/resources/application-dev.yaml
@@ -21,7 +21,7 @@ spring:
     oauth2:
       resourceserver:
         jwt:
-          issuer-uri: ${AZURE_APP_WELL_KNOWN_URL}
+          issuer-uri: ${AZURE_OPENID_CONFIG_ISSUER}
           audiences: ${AZURE_APP_CLIENT_ID}
 
 vault:
@@ -31,4 +31,5 @@ vault:
 
 OPPDRAG_SERVICE_URL: #Mockes ut lokalt
 SECURITYTOKENSERVICE_URL: https://localhost:8063/soap/SecurityTokenServiceProvider/
-AZURE_APP_WELL_KNOWN_URL: "https://login.microsoftonline.com/navq.onmicrosoft.com/v2.0/.well-known/openid-configuration"
+AZURE_OPENID_CONFIG_ISSUER: "https://login.microsoftonline.com/navq.onmicrosoft.com/v2.0"
+AZURE_APP_CLIENT_ID: "local-client-id"

--- a/src/test/resources/application-dev_psql_mq.yaml
+++ b/src/test/resources/application-dev_psql_mq.yaml
@@ -9,15 +9,18 @@ oppdrag.mq:
   port: ${OPPDRAG_MQ_PORT_OVERRIDE}
   enabled: true
 
-no.nav.security.jwt:
-  issuer.azuread:
-    discoveryurl: ${AZURE_APP_WELL_KNOWN_URL}
-    accepted_audience: ${AZURE_APP_CLIENT_ID}
-
-spring.datasource.url: ${SPRING_DATASOURCE_URL_OVERRIDE}
-spring.datasource.username: ${SPRING_DATASOURCE_USERNAME_OVERRIDE}
-spring.datasource.password: ${SPRING_DATASOURCE_PASSWORD_OVERRIDE}
-spring.datasource.driver-class-name: ${SPRING_DATASOURCE_DRIVER_OVERRIDE}
+spring:
+  datasource:
+    url: ${SPRING_DATASOURCE_URL_OVERRIDE}
+    username: ${SPRING_DATASOURCE_USERNAME_OVERRIDE}
+    password: ${SPRING_DATASOURCE_PASSWORD_OVERRIDE}
+    driver-class-name: ${SPRING_DATASOURCE_DRIVER_OVERRIDE}
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri: ${AZURE_APP_WELL_KNOWN_URL}
+          audiences: ${AZURE_APP_CLIENT_ID}
 
 vault:
   systembruker:

--- a/src/test/resources/application-dev_psql_mq.yaml
+++ b/src/test/resources/application-dev_psql_mq.yaml
@@ -19,7 +19,7 @@ spring:
     oauth2:
       resourceserver:
         jwt:
-          issuer-uri: ${AZURE_APP_WELL_KNOWN_URL}
+          issuer-uri: ${AZURE_OPENID_CONFIG_ISSUER}
           audiences: ${AZURE_APP_CLIENT_ID}
 
 vault:
@@ -29,4 +29,5 @@ vault:
 
 SECURITYTOKENSERVICE_URL: https://localhost:8063/soap/SecurityTokenServiceProvider/
 OPPDRAG_SERVICE_URL: #Mockes ut lokalt
-AZURE_APP_WELL_KNOWN_URL: "https://login.microsoftonline.com/navq.onmicrosoft.com/v2.0/.well-known/openid-configuration"
+AZURE_OPENID_CONFIG_ISSUER: "https://login.microsoftonline.com/navq.onmicrosoft.com/v2.0"
+AZURE_APP_CLIENT_ID: "local-client-id"


### PR DESCRIPTION
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/1844bbac3b6605eacc8f5543?card=Nav-29073

Legg til spring security
Kun Azure-AD så konfigurerer i application.yaml

Test bruker WebMvcTest og laster ikke inn service-layeret/handlere, så tester virkelig kun sikkerhetslaget. 